### PR TITLE
Add sentry-sdk

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 argparse
+sentry-sdk


### PR DESCRIPTION
Steps to check it was necessary:

- Created a Python3.7 virtual environment: `virtualenv --python=/usr/bin/python3.7 .testenv`
- Ran: `pip3 install -r requirements.txt`
- Ran: ` python3 setup.py install`
- Ran: `norminette`
- Got: `ModuleNotFoundError: No module named 'sentry_sdk'`
- Added `sentry-sdk` to requirements.txt
- Command `norminette` now works.
- Made sure that run_test.sh properly runs after modifications.