### PR TITLE
Fix exit code and sentry

### DIFF
--- a/norminette/__main__.py
+++ b/norminette/__main__.py
@@ -14,7 +14,8 @@ import _thread
 from threading import Thread, Event
 from multiprocessing import Process, Queue
 import time
-from sentry_sdk import configure_scope
+#import sentry_sdk
+#from sentry_sdk import configure_scope
 from version import __version__
 
 has_err = False
@@ -66,8 +67,8 @@ def main():
         if target[-2:] not in [".c", ".h"]:
             print(f"{arg} is not valid C or C header file")
         else:
-            with configure_scope() as scope:
-                scope.set_extra("File", target)
+            #with configure_scope() as scope:
+            #    scope.set_extra("File", target)
             try:
                 event.append(Event())
                 #if args.sentry == True:

--- a/norminette/__main__.py
+++ b/norminette/__main__.py
@@ -86,7 +86,7 @@ def main():
                 context = Context(target, tokens, debug)
                 registry.run(context, source)
                 event[-1].set()
-                if context.errors is not []:
+                if context.errors:
                     has_err = True
             # except (TokenError, CParsingError) as e:
             except TokenError as e:


### PR DESCRIPTION
Bug 1: Exit code is always 1, even if all files are OK (should be 0)
Cause: `if context.errors is not []` always returns `True`, even when `context.errors` is empty
Fix: Used `if context.errors` instead

Bug 2: sentry_sdk is still used by code, thought last commit (https://github.com/42School/norminette/commit/511cd414dbae818278fd02a9e7c953e8668bfcf5) removed the `import sentry` line
Cause: `configure_scope` from sentry is still used
Fix: Commented lines still using sentry