### PR TITLE
fix: fix indentation computing

### DIFF
--- a/norminette/rules/check_prototype_indent.py
+++ b/norminette/rules/check_prototype_indent.py
@@ -68,7 +68,7 @@ class CheckPrototypeIndent(Rule):
                 else:
                     id_length = context.peek_token(i).length
                 current_indent += math.floor((id_length + buffer_len) / 4)
-                buffer_len = 0
+                buffer_len = (id_length + buffer_len) % 4
             elif context.check_token(i, "SPACE") is True and type_identifier_nb > 0:
                 buffer_len += 1
             elif context.check_token(i, "SPACE") is True and type_identifier_nb == 0:
@@ -77,6 +77,7 @@ class CheckPrototypeIndent(Rule):
             elif context.check_token(i, "TAB") is True and type_identifier_nb == 0:
                 has_tab += 1
                 current_indent += 1
+                buffer_len = 0
             elif context.check_token(i, "IDENTIFIER") is True and type_identifier_nb == 0:
                 if context.scope.func_alignment == 0:
                     context.scope.func_alignment = current_indent


### PR DESCRIPTION
Refers to https://github.com/42School/norminette/issues/11

We need to keep the modulo of characters divided by 4 (length of the tab).

Signed-off-by: D4ryl00 <d4ryl00@gmail.com>