### PR TITLE
Allign column and line before displaying error.

### DIFF
--- a/norminette/norm_error.py
+++ b/norminette/norm_error.py
@@ -94,9 +94,9 @@ class NormError:
         self.line = line
         self.col = col
         if col is not None:
-            self.error_pos = f"(line: {self.line}, col: {self.col}):\t"
+            self.error_pos = f"(line: {(str(self.line)).rjust(3)}, col: {(str(self.col)).rjust(3)}):\t"
         else:
-            self.error_pos = f"(line: {self.line}):\t "
+            self.error_pos = f"(line: {(str(self.line)).rjust(3)}):\t "
         self.prefix = f"\t{self.errno:<20} {self.error_pos:>21}"
         self.error_msg = f"{errors.get(self.errno, 'ERROR NOT FOUND')}"
 


### PR DESCRIPTION
Before:
```
vector.c: KO!
	SPACE_REPLACE_TAB    (line: 19, col: 11):	Found space when expecting tab
	SPACE_REPLACE_TAB    (line: 44, col: 11):	Found space when expecting tab
	SPACE_EMPTY_LINE      (line: 45, col: 1):	Space on empty line
	TOO_MANY_FUNCS        (line: 52, col: 1):	Too many functions in file
	SPACE_REPLACE_TAB    (line: 54, col: 11):	Found space when expecting tab
	SPACE_EMPTY_LINE      (line: 55, col: 1):	Space on empty line
	TOO_MANY_FUNCS        (line: 92, col: 1):	Too many functions in file
	SPACE_REPLACE_TAB    (line: 94, col: 111):	Found space when expecting tab
```
After:
```
vector.c: KO!
	SPACE_REPLACE_TAB    (line:  19, col:  11):	Found space when expecting tab
	SPACE_REPLACE_TAB    (line:  44, col:  11):	Found space when expecting tab
	SPACE_EMPTY_LINE     (line:  45, col:   1):	Space on empty line
	TOO_MANY_FUNCS       (line:  52, col:   1):	Too many functions in file
	SPACE_REPLACE_TAB    (line:  54, col:  11):	Found space when expecting tab
	SPACE_EMPTY_LINE     (line:  55, col:   1):	Space on empty line
	TOO_MANY_FUNCS       (line:  92, col:   1):	Too many functions in file
	SPACE_REPLACE_TAB    (line:  94, col: 111):	Found space when expecting tab
```