### PR TITLE
Dockerfile : Change working directory to /code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,9 @@ WORKDIR /usr/src/norminette
 
 COPY . .
 
-RUN pip3 install -r requirements.txt
-RUN python3 setup.py install
+RUN pip3 install -r requirements.txt \
+	&& python3 setup.py install
+
+WORKDIR /code
 
 ENTRYPOINT ["norminette"]


### PR DESCRIPTION
Running norminette with docker on some files is not really convenient.
We should prepend `/code` for each argument.
```bash
docker run -v $PWD:/code norminette code/srcs/file.c code/includes code/file2.c
```
Can we change the working directory to `/code` ?
```bash
docker run -v $PWD:/code norminette srcs/file.c includes file2.c
```
Also, being directly in `/code` allow for autocompletion of the files.

@alexandregv  Does something relies being in the norminette's folder by default ? (like tests, or something else ?)
