### PR TITLE
Add timeout to job + fix run_tests.sh

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,6 +17,7 @@ jobs:
       matrix:
         python-version: [3.7, 3.8, 3.9]
 
+    timeout-minutes: 5
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/norminette/run_test.sh
+++ b/norminette/run_test.sh
@@ -1,5 +1,6 @@
 #!/bin/env sh
 
+python3 --version
 set -ex
 
 echo "Running lexer unit test:"

--- a/norminette/run_test.sh
+++ b/norminette/run_test.sh
@@ -1,6 +1,10 @@
+#!/bin/env sh
+
+set -ex
+
 echo "Running lexer unit test:"
-python -m unittest discover tests/lexer/unit-tests/ "*.py"
+python3 -m unittest discover tests/lexer/unit-tests/ "*.py"
 echo "Running lexer test on files:"
-python -m  tests.lexer.files.file_token_test
-python -m tests.lexer.errors.tester
-python -m tests.rules.rule_tester
+python3 -m  tests.lexer.files.file_token_test
+python3 -m tests.lexer.errors.tester
+python3 -m tests.rules.rule_tester


### PR DESCRIPTION
#### Change default job timeout from 6h to 5min.

#### Fix run_tests.sh:
The job was able to  succeed even if a command failed in the script, example:
![Screenshot from 2021-03-06 15-19-19](https://user-images.githubusercontent.com/13398285/110210859-ea3b9e00-7e93-11eb-8764-1b60b5efaa1b.png)
  - `set -e` ensure to exit the script at the first command that fail.


- set -x :  to know which command failed (print each executed command)
Without :
![Screenshot from 2021-03-06 14-33-14](https://user-images.githubusercontent.com/13398285/110210887-17884c00-7e94-11eb-89df-ae6af7b651d3.png)
it said it was cancelled, but it was not, I tested a timeout.
Now with `set -x` :
![Screenshot from 2021-03-06 15-24-28](https://user-images.githubusercontent.com/13398285/110210683-1571bd80-7e93-11eb-96ae-a1b8a12f3680.png)


    



I have tested everything on a PR in my fork: 
https://github.com/ggjulio/norminette/pull/4#partial-pull-merging