### PR TITLE
translation mistake fixed

### DIFF
--- a/pdf/en.norm.tex
+++ b/pdf/en.norm.tex
@@ -159,7 +159,7 @@
 
                 \item You may add a new line after an instruction or
                   control structure, but you'll have to add an
-                  indentation with brackets or affectation operator.
+                  indentation with brackets or assignment operator.
                   Operators must be at the beginning of a line.
 
                 \item Control structures (if, while..) must have braces, unless they contain a single 


### PR DESCRIPTION
The French word "d'affectation" should be translated as "assignment", but it was mistakenly translated as "affectation"