### PR TITLE
Update en.norm.tex

### DIFF
--- a/pdf/en.norm.tex
+++ b/pdf/en.norm.tex
@@ -163,7 +163,9 @@
 
                 \item Control structures (if, while..) must have braces, unless they contain a single 
                     line or a single condition.
-
+                
+                \item Braces following functions, declarators or control structures must be preceded and followed by a newline.
+                
             \end{itemize}
 
             \newpage


### PR DESCRIPTION
Make more explicit in the PDF that Brackets must be in its own line as in:
int main(void)
{
    return(0);
}
as opposed of:
int main(void) {
    return(0);
}