### PR TITLE
Add specific version installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ python3 -m pip install --upgrade pip setuptools
 python3 -m pip install norminette
 ```
 
+To install a specific version (here 3.3.50), use
+```shell
+python3 -m pip install norminette==3.3.50
+```
+
 To upgrade an existing install, use
 ```shell
 python3 -m pip install --upgrade norminette


### PR DESCRIPTION
When a campus is not using the latest version yet, students should be able to install a specific version of the norminette easily, so I added those instructions in the README.