### PR TITLE
Add new NO_SPC_AFTER_SIGN error and replace a wrong SPC_AFTER_OPERATOR with it

### DIFF
--- a/norminette/norm_error.py
+++ b/norminette/norm_error.py
@@ -6,6 +6,7 @@ errors = {
     "SPC_AFTER_OPERATOR": "missing space after operator",
     "NO_SPC_BFR_OPR": "extra space before operator",
     "NO_SPC_AFR_OPR": "extra space after operator",
+    "NO_SPC_AFTER_SIGN": "Extra space after sign",
     "SPC_AFTER_PAR": "Missing space after parenthesis (brace/bracket)",
     "SPC_BFR_PAR": "Missing space before parenthesis (brace/bracket)",
     "NO_SPC_AFR_PAR": "Extra space after parenthesis (brace/bracket)",

--- a/norminette/rules/check_operators_spacing.py
+++ b/norminette/rules/check_operators_spacing.py
@@ -358,7 +358,7 @@ class CheckOperatorsSpacing(Rule):
             "LBRACE",
         ]
         if context.check_token(pos + 1, ["SPACE", "TAB"]) is True:
-            context.new_error("SPC_AFTER_OPERATOR", context.peek_token(pos))
+            context.new_error("NO_SPC_AFTER_SIGN", context.peek_token(pos))
         pos -= 1
         if context.check_token(pos, glued + ["SPACE", "TAB"] + glued_operators) is False:
             context.new_error("SPC_BFR_OPERATOR", context.peek_token(pos))


### PR DESCRIPTION
This PR fixes #263 by adding a new NO_SPC_AFTER_SIGN error type and replacing the incorrect SPC_AFTER_OPERATOR in check_operators_spacing rule.

Tests are passing and I tested it against various similar situations:
`i = -1;`
`i = - 1;`
`i = 1 - 1;`
`i = 1-1;`
`i = 1 -1;`
`i = 1- 1;`