### PR TITLE
Replace Ok! and Error! with a green [OK] and a red [KO] respectively.

### DIFF
--- a/norminette/registry.py
+++ b/norminette/registry.py
@@ -87,9 +87,9 @@ class Registry:
             if context.debug > 0:
                 print("uncaught ->", unrecognized_tkns)
         if context.errors == []:
-            print(context.filename + ": OK!")
+            print("\033[92m[OK]\033[0m " + context.filename)
         else:
-            print(context.filename + ": Error!")
+            print("\033[91m[KO]\033[0m " + context.filename)
             context.errors = sorted(context.errors + context.warnings, key=cmp_to_key(sort_errs))
             for err in context.errors:
                 print(err)


### PR DESCRIPTION
Replace Ok! and Error! with a green [OK] and a red [KO] respectively, and made them as a prefix instead of postfix for readability, (Tests don't work well, since they expect the previous format).
### ⚠️ Tests need to be modified to match the new messages format: ⚠️
### Examples
<img width="598" alt="Screen Shot 2022-02-13 at 6 23 57 PM" src="https://user-images.githubusercontent.com/41086428/153767491-259c7977-857c-4115-a568-fd9236b56c76.png">
