### PR TITLE
Update the max function count up to 7

### DIFF
--- a/norminette/rules/check_functions_count.py
+++ b/norminette/rules/check_functions_count.py
@@ -8,9 +8,9 @@ class CheckFunctionsCount(Rule):
 
     def run(self, context):
         """
-        Each file cannot contain more than 5 function
+        Each file cannot contain more than 7 functions
         """
         if context.scope != None and context.scope.name == "GlobalScope":
-            if context.scope.functions > 5:
+            if context.scope.functions > 7:
                 context.new_error("TOO_MANY_FUNCS", context.peek_token(0))
         return False, 0


### PR DESCRIPTION
Having a function count of 5 is annoying, especially considering that most professional projects have a few dozen functions within a single file. This not only hinders the structural integrity of the developer's project (often having to create a 2nd file for no reason, like `str.c` and `str2.c`), but, as stated previously, does not reflect real-world use cases.

I did consider that the limit was imposed to reduce correction time, but adding 2 extra functions to this rule should not over-complicate things drastically.

Plus with the extra help we get from our IDEs, clicking on any function with the CMD or CTRL key jumps straight to that function, which should eliminate any opposition to this PR.

