### PR TITLE
add to PreProcessors only hold positive numbers

### DIFF
--- a/norminette/context.py
+++ b/norminette/context.py
@@ -166,6 +166,14 @@ class PreProcessors:
 
         self.skip_define = False
 
+    @property
+    def indent(self):
+        return self._indent
+
+    @indent.setter
+    def indent(self, value):
+        self._indent = max(0, value)
+
     def has_macro_defined(self, name):
         for macro in self.macros:
             if macro.name == name:

--- a/norminette/rules/check_preprocessor_indent.py
+++ b/norminette/rules/check_preprocessor_indent.py
@@ -59,6 +59,7 @@ class CheckPreprocessorIndent(Rule):
             t = context.peek_token(i)
             if t and t.type == "IDENTIFIER" and t.value.upper() in ("IFNDEF", "IFDEF", "ELIF"):
                 indent -= 1
+        indent = max(0, indent)
         if spaces > indent:
             context.new_error("TOO_MANY_WS", hash_)
         if spaces < indent:

--- a/tests/rules/samples/check_preprocessor_indent_2.c
+++ b/tests/rules/samples/check_preprocessor_indent_2.c
@@ -1,0 +1,10 @@
+#endif
+#else
+#endif
+#else
+#endif
+#endif
+#endif
+#else
+#else
+#endif

--- a/tests/rules/samples/check_preprocessor_indent_2.c
+++ b/tests/rules/samples/check_preprocessor_indent_2.c
@@ -8,3 +8,9 @@
 #else
 #else
 #endif
+// Ok
+#if 1
+#endif
+// END Ok
+#else
+#endif

--- a/tests/rules/samples/check_preprocessor_indent_2.out
+++ b/tests/rules/samples/check_preprocessor_indent_2.out
@@ -18,6 +18,18 @@
 		<HASH> <ELSE> <NEWLINE>
 [36mcheck_preprocessor_indent_2.c[0m - [32mIsPreprocessorStatement[0m In "GlobalScope" from "None" line 10":
 		<HASH> <IDENTIFIER=endif> <NEWLINE>
+[36mcheck_preprocessor_indent_2.c[0m - [32mIsComment[0m In "GlobalScope" from "None" line 11":
+		<COMMENT=// Ok> <NEWLINE>
+[36mcheck_preprocessor_indent_2.c[0m - [32mIsPreprocessorStatement[0m In "GlobalScope" from "None" line 12":
+		<HASH> <IF> <SPACE> <CONSTANT=1> <NEWLINE>
+[36mcheck_preprocessor_indent_2.c[0m - [32mIsPreprocessorStatement[0m In "GlobalScope" from "None" line 13":
+		<HASH> <IDENTIFIER=endif> <NEWLINE>
+[36mcheck_preprocessor_indent_2.c[0m - [32mIsComment[0m In "GlobalScope" from "None" line 14":
+		<COMMENT=// END Ok> <NEWLINE>
+[36mcheck_preprocessor_indent_2.c[0m - [32mIsPreprocessorStatement[0m In "GlobalScope" from "None" line 15":
+		<HASH> <ELSE> <NEWLINE>
+[36mcheck_preprocessor_indent_2.c[0m - [32mIsPreprocessorStatement[0m In "GlobalScope" from "None" line 16":
+		<HASH> <IDENTIFIER=endif> <NEWLINE>
 check_preprocessor_indent_2.c: Error!
 Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
 Error: PREPROC_BAD_ENDIF    (line:   1, col:   1):	Endif preprocessor statement without if, elif or else
@@ -30,3 +42,5 @@ Error: PREPROC_BAD_ENDIF    (line:   7, col:   1):	Endif preprocessor statement 
 Error: PREPROC_BAD_ELSE     (line:   8, col:   1):	Else preprocessor statement without if or elif
 Error: PREPROC_BAD_ELSE     (line:   9, col:   1):	Else preprocessor statement without if or elif
 Error: PREPROC_BAD_ENDIF    (line:  10, col:   1):	Endif preprocessor statement without if, elif or else
+Error: PREPROC_BAD_ELSE     (line:  15, col:   1):	Else preprocessor statement without if or elif
+Error: PREPROC_BAD_ENDIF    (line:  16, col:   1):	Endif preprocessor statement without if, elif or else

--- a/tests/rules/samples/check_preprocessor_indent_2.out
+++ b/tests/rules/samples/check_preprocessor_indent_2.out
@@ -1,0 +1,32 @@
+[36mcheck_preprocessor_indent_2.c[0m - [32mIsPreprocessorStatement[0m In "GlobalScope" from "None" line 1":
+		<HASH> <IDENTIFIER=endif> <NEWLINE>
+[36mcheck_preprocessor_indent_2.c[0m - [32mIsPreprocessorStatement[0m In "GlobalScope" from "None" line 2":
+		<HASH> <ELSE> <NEWLINE>
+[36mcheck_preprocessor_indent_2.c[0m - [32mIsPreprocessorStatement[0m In "GlobalScope" from "None" line 3":
+		<HASH> <IDENTIFIER=endif> <NEWLINE>
+[36mcheck_preprocessor_indent_2.c[0m - [32mIsPreprocessorStatement[0m In "GlobalScope" from "None" line 4":
+		<HASH> <ELSE> <NEWLINE>
+[36mcheck_preprocessor_indent_2.c[0m - [32mIsPreprocessorStatement[0m In "GlobalScope" from "None" line 5":
+		<HASH> <IDENTIFIER=endif> <NEWLINE>
+[36mcheck_preprocessor_indent_2.c[0m - [32mIsPreprocessorStatement[0m In "GlobalScope" from "None" line 6":
+		<HASH> <IDENTIFIER=endif> <NEWLINE>
+[36mcheck_preprocessor_indent_2.c[0m - [32mIsPreprocessorStatement[0m In "GlobalScope" from "None" line 7":
+		<HASH> <IDENTIFIER=endif> <NEWLINE>
+[36mcheck_preprocessor_indent_2.c[0m - [32mIsPreprocessorStatement[0m In "GlobalScope" from "None" line 8":
+		<HASH> <ELSE> <NEWLINE>
+[36mcheck_preprocessor_indent_2.c[0m - [32mIsPreprocessorStatement[0m In "GlobalScope" from "None" line 9":
+		<HASH> <ELSE> <NEWLINE>
+[36mcheck_preprocessor_indent_2.c[0m - [32mIsPreprocessorStatement[0m In "GlobalScope" from "None" line 10":
+		<HASH> <IDENTIFIER=endif> <NEWLINE>
+check_preprocessor_indent_2.c: Error!
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: PREPROC_BAD_ENDIF    (line:   1, col:   1):	Endif preprocessor statement without if, elif or else
+Error: PREPROC_BAD_ELSE     (line:   2, col:   1):	Else preprocessor statement without if or elif
+Error: PREPROC_BAD_ENDIF    (line:   3, col:   1):	Endif preprocessor statement without if, elif or else
+Error: PREPROC_BAD_ELSE     (line:   4, col:   1):	Else preprocessor statement without if or elif
+Error: PREPROC_BAD_ENDIF    (line:   5, col:   1):	Endif preprocessor statement without if, elif or else
+Error: PREPROC_BAD_ENDIF    (line:   6, col:   1):	Endif preprocessor statement without if, elif or else
+Error: PREPROC_BAD_ENDIF    (line:   7, col:   1):	Endif preprocessor statement without if, elif or else
+Error: PREPROC_BAD_ELSE     (line:   8, col:   1):	Else preprocessor statement without if or elif
+Error: PREPROC_BAD_ELSE     (line:   9, col:   1):	Else preprocessor statement without if or elif
+Error: PREPROC_BAD_ENDIF    (line:  10, col:   1):	Endif preprocessor statement without if, elif or else


### PR DESCRIPTION
If we put too many `endif` or `else` without a pair, we get too many “TOO_MANY_WS” errors:
```c
#endif
#endif
#endif
#endif
#endif
#endif
```
```
Error: INVALID_HEADER       (line:   1, col:   1):      Missing or invalid 42 header
Error: PREPROC_BAD_ENDIF    (line:   1, col:   1):      Endif preprocessor statement without if, elif or else
Error: TOO_MANY_WS          (line:   1, col:   1):      Extra whitespaces for indent level
Error: TOO_MANY_WS          (line:   2, col:   1):      Extra whitespaces for indent level
Error: TOO_MANY_WS          (line:   3, col:   1):      Extra whitespaces for indent level
Error: TOO_MANY_WS          (line:   4, col:   1):      Extra whitespaces for indent level
Error: TOO_MANY_WS          (line:   5, col:   1):      Extra whitespaces for indent level
Error: TOO_MANY_WS          (line:   6, col:   1):      Extra whitespaces for indent level
```
To fix it, we can change the indentation value to `max(0, indent)` in `CheckPreprocessorIndent`, but we won't get the errors that every endif must have a `#if`, `#elif` or `# else`, because in `IsPreprocessorStatement` we check whether the indent `== 0` instead of `< 1`.

To fix these two bugs, we need to make `indent` hold only positive integers as a value. Result:
```
Error: INVALID_HEADER       (line:   1, col:   1):      Missing or invalid 42 header
Error: PREPROC_BAD_ENDIF    (line:   1, col:   1):      Endif preprocessor statement without if, elif or else
Error: PREPROC_BAD_ENDIF    (line:   2, col:   1):      Endif preprocessor statement without if, elif or else
Error: PREPROC_BAD_ENDIF    (line:   3, col:   1):      Endif preprocessor statement without if, elif or else
Error: PREPROC_BAD_ENDIF    (line:   4, col:   1):      Endif preprocessor statement without if, elif or else
Error: PREPROC_BAD_ENDIF    (line:   5, col:   1):      Endif preprocessor statement without if, elif or else
Error: PREPROC_BAD_ENDIF    (line:   6, col:   1):      Endif preprocessor statement without if, elif or else
```