### PR TITLE
fix: add to avoid calculating the length of a escaped char in char_constant_function

### DIFF
--- a/norminette/lexer/lexer.py
+++ b/norminette/lexer/lexer.py
@@ -133,9 +133,6 @@ class Lexer:
                 self.tokens.append(Token("TKN_ERROR", pos))
                 return
             if self.peek_char() == "'":
-                for i in tkn_value:
-                    if i == "\\":
-                        self.__line_pos += 1
                 self.pop_char()
                 self.tokens.append(Token("CHAR_CONST", pos, tkn_value))
                 return

--- a/tests/rules/samples/test_file_2007.c
+++ b/tests/rules/samples/test_file_2007.c
@@ -10,5 +10,7 @@ int	philo(int argc, char const *argv[], char *const envp[])
 		ft_putstr("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n");
 		ft_putstr("time_to_eat time_to_sleep [number_of_times_each_philosopher");
 	}
+	if (c == ' ' & c == '\t' & c == '\n' & c == '\v' & c == '\f' & c == '\r')
+		return (1);
 	(void) argv;
 }

--- a/tests/rules/samples/test_file_2007.out
+++ b/tests/rules/samples/test_file_2007.out
@@ -22,9 +22,13 @@
 		<TAB> <TAB> <IDENTIFIER=ft_putstr> <LPARENTHESIS> <STRING="time_to_eat time_to_sleep [number_of_times_each_philosopher"> <RPARENTHESIS> <SEMI_COLON> <NEWLINE>
 [36mtest_file_2007.c[0m - [32mIsBlockEnd[0m In "ControlStructure" from "Function" line 12":
 		<TAB> <RBRACE> <NEWLINE>
-[36mtest_file_2007.c[0m - [32mIsExpressionStatement[0m In "Function" from "GlobalScope" line 13":
+[36mtest_file_2007.c[0m - [32mIsControlStatement[0m In "Function" from "GlobalScope" line 13":
+		<TAB> <IF> <SPACE> <LPARENTHESIS> <IDENTIFIER=c> <SPACE> <EQUALS> <SPACE> <CHAR_CONST=' '> <SPACE> <BWISE_AND> <SPACE> <IDENTIFIER=c> <SPACE> <EQUALS> <SPACE> <CHAR_CONST='\t'> <SPACE> <BWISE_AND> <SPACE> <IDENTIFIER=c> <SPACE> <EQUALS> <SPACE> <CHAR_CONST='\n'> <SPACE> <BWISE_AND> <SPACE> <IDENTIFIER=c> <SPACE> <EQUALS> <SPACE> <CHAR_CONST='\v'> <SPACE> <BWISE_AND> <SPACE> <IDENTIFIER=c> <SPACE> <EQUALS> <SPACE> <CHAR_CONST='\f'> <SPACE> <BWISE_AND> <SPACE> <IDENTIFIER=c> <SPACE> <EQUALS> <SPACE> <CHAR_CONST='\r'> <RPARENTHESIS> <NEWLINE>
+[36mtest_file_2007.c[0m - [32mIsExpressionStatement[0m In "ControlStructure" from "Function" line 14":
+		<TAB> <TAB> <RETURN> <SPACE> <LPARENTHESIS> <CONSTANT=1> <RPARENTHESIS> <SEMI_COLON> <NEWLINE>
+[36mtest_file_2007.c[0m - [32mIsExpressionStatement[0m In "Function" from "GlobalScope" line 15":
 		<TAB> <LPARENTHESIS> <VOID> <RPARENTHESIS> <SPACE> <IDENTIFIER=argv> <SEMI_COLON> <NEWLINE>
-[36mtest_file_2007.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 14":
+[36mtest_file_2007.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 16":
 		<RBRACE> <NEWLINE>
 test_file_2007.c: Error!
 Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header


### PR DESCRIPTION
Fixes #447. Relates to #413.