### PR TITLE
Improve Rule classes to be able add a rich context.history in Rules

### DIFF
--- a/norminette/rules/check_assignation.py
+++ b/norminette/rules/check_assignation.py
@@ -1,4 +1,4 @@
-from norminette.rules import Rule
+from norminette.rules import Rule, Check
 
 assigns = [
     "RIGHT_ASSIGN",
@@ -17,10 +17,10 @@ assigns = [
 special_assigns = ["INC", "DEC"]
 
 
-class CheckAssignation(Rule):
-    def __init__(self):
-        super().__init__()
-        self.depends_on = ["IsAssignation"]
+class CheckAssignation(Rule, Check):
+    depends_on = (
+        "IsAssignation",
+    )
 
     def check_brace_assign(self, context, i):
         i += 1

--- a/norminette/rules/check_assignation_indent.py
+++ b/norminette/rules/check_assignation_indent.py
@@ -1,4 +1,4 @@
-from norminette.rules import Rule
+from norminette.rules import Rule, Check
 from norminette.exceptions import CParsingError
 
 
@@ -42,15 +42,13 @@ operators = [
 nest_kw = ["RPARENTHESIS", "LPARENTHESIS", "NEWLINE"]
 
 
-class CheckAssignationIndent(Rule):
-    def __init__(self):
-        super().__init__()
-        self.depends_on = [
-            "IsAssignation",
-            "IsFuncPrototype",
-            "IsFunctionCall",
-            "IsVarDeclaration",
-        ]
+class CheckAssignationIndent(Rule, Check):
+    depends_on = (
+        "IsAssignation",
+        "IsFuncPrototype",
+        "IsFunctionCall",
+        "IsVarDeclaration",
+    )
 
     def run(self, context):
         """

--- a/norminette/rules/check_block_start.py
+++ b/norminette/rules/check_block_start.py
@@ -1,11 +1,11 @@
-from norminette.rules import Rule
+from norminette.rules import Rule, Check
 from norminette.scope import GlobalScope, ControlStructure
 
 
-class CheckBlockStart(Rule):
-    def __init__(self):
-        super().__init__()
-        self.depends_on = ["IsBlockStart"]
+class CheckBlockStart(Rule, Check):
+    depends_on = (
+        "IsBlockStart",
+    )
 
     def run(self, context):
         """

--- a/norminette/rules/check_brace.py
+++ b/norminette/rules/check_brace.py
@@ -1,10 +1,11 @@
-from norminette.rules import Rule
+from norminette.rules import Rule, Check
 
 
-class CheckBrace(Rule):
-    def __init__(self):
-        super().__init__()
-        self.depends_on = ["IsBlockStart", "IsBlockEnd"]
+class CheckBrace(Rule, Check):
+    depends_on = (
+        "IsBlockStart",
+        "IsBlockEnd",
+    )
 
     def run(self, context):
         """

--- a/norminette/rules/check_comment.py
+++ b/norminette/rules/check_comment.py
@@ -1,13 +1,9 @@
-from norminette.rules import Rule
+from norminette.rules import Rule, Check
 
 allowed_on_comment = ["COMMENT", "MULT_COMMENT", "SPACE", "TAB"]
 
 
-class CheckComment(Rule):
-    def __init__(self):
-        super().__init__()
-        self.depends_on = []
-
+class CheckComment(Rule, Check):
     def run(self, context):
         """
         Comments are only allowed in GlobalScope.

--- a/norminette/rules/check_comment_line_len.py
+++ b/norminette/rules/check_comment_line_len.py
@@ -1,10 +1,10 @@
-from norminette.rules import Rule
+from norminette.rules import Rule, Check
 
 
-class CheckCommentLineLen(Rule):
-    def __init__(self):
-        super().__init__()
-        self.depends_on = ["IsComment"]
+class CheckCommentLineLen(Rule, Check):
+    depends_on = (
+        "IsComment",
+    )
 
     def run(self, context):
         """

--- a/norminette/rules/check_control_statement.py
+++ b/norminette/rules/check_control_statement.py
@@ -1,4 +1,4 @@
-from norminette.rules import Rule
+from norminette.rules import Rule, Check
 
 
 forbidden_cs = ["FOR", "SWITCH", "CASE", "GOTO"]
@@ -17,10 +17,10 @@ assigns = [
 ]
 
 
-class CheckControlStatement(Rule):
-    def __init__(self):
-        super().__init__()
-        self.depends_on = ["IsControlStatement"]
+class CheckControlStatement(Rule, Check):
+    depends_on = (
+        "IsControlStatement",
+    )
 
     def check_nest(self, context, i):
         depth = 1

--- a/norminette/rules/check_declaration.py
+++ b/norminette/rules/check_declaration.py
@@ -1,10 +1,10 @@
-from norminette.rules import Rule
+from norminette.rules import Rule, Check
 
 
-class CheckDeclaration(Rule):
-    def __init__(self):
-        super().__init__()
-        self.depends_on = ["IsDeclaration"]
+class CheckDeclaration(Rule, Check):
+    depends_on = (
+        "IsDeclaration",
+    )
 
     def run(self, context):
         """

--- a/norminette/rules/check_empty_line.py
+++ b/norminette/rules/check_empty_line.py
@@ -1,11 +1,7 @@
-from norminette.rules import Rule
+from norminette.rules import Rule, Check
 
 
-class CheckEmptyLine(Rule):
-    def __init__(self):
-        super().__init__()
-        self.depends_on = []
-
+class CheckEmptyLine(Rule, Check):
     def run(self, context):
         """
         Empty line must not contains tabs or spaces

--- a/norminette/rules/check_enum_var_decl.py
+++ b/norminette/rules/check_enum_var_decl.py
@@ -1,10 +1,10 @@
-from norminette.rules import Rule
+from norminette.rules import Rule, Check
 
 
-class CheckEnumVarDecl(Rule):
-    def __init__(self):
-        super().__init__()
-        self.depends_on = ["IsEnumVarDecl"]
+class CheckEnumVarDecl(Rule, Check):
+    depends_on = (
+        "IsEnumVarDecl",
+    )
 
     def run(self, context):
         """

--- a/norminette/rules/check_expression_statement.py
+++ b/norminette/rules/check_expression_statement.py
@@ -1,4 +1,4 @@
-from norminette.rules import Rule
+from norminette.rules import Rule, Check
 
 kw = [
     # C reserved keywords #
@@ -36,16 +36,14 @@ kw = [
 ]
 
 
-class CheckExpressionStatement(Rule):
-    def __init__(self):
-        super().__init__()
-        self.depends_on = [
-            "IsExpressionStatement",
-            "IsControlStatement",
-            "IsFunctionCall",
-            "IsAssignation",
-            "IsCast",
-        ]
+class CheckExpressionStatement(Rule, Check):
+    depends_on = (
+        "IsExpressionStatement",
+        "IsControlStatement",
+        "IsFunctionCall",
+        "IsAssignation",
+        "IsCast",
+    )
 
     def run(self, context):
         """

--- a/norminette/rules/check_func_arguments_name.py
+++ b/norminette/rules/check_func_arguments_name.py
@@ -1,4 +1,4 @@
-from norminette.rules import Rule
+from norminette.rules import Rule, Check
 
 type_specifiers = ["CHAR", "DOUBLE", "ENUM", "FLOAT", "INT", "UNION", "VOID", "SHORT"]
 
@@ -13,10 +13,11 @@ whitespaces = ["SPACE", "TAB", "NEWLINE"]
 arg_separator = ["COMMA", "CLOSING_PARENTHESIS"]
 
 
-class CheckFuncArgumentsName(Rule):
-    def __init__(self):
-        super().__init__()
-        self.depends_on = ["IsFuncDeclaration", "IsFuncPrototype"]
+class CheckFuncArgumentsName(Rule, Check):
+    depends_on = (
+        "IsFuncDeclaration",
+        "IsFuncPrototype",
+    )
 
     def check_arg_format(self, context, pos):
         """

--- a/norminette/rules/check_func_declaration.py
+++ b/norminette/rules/check_func_declaration.py
@@ -1,16 +1,14 @@
-from norminette.rules import Rule
+from norminette.rules import Rule, Check
 
 types = ["INT", "FLOAT", "CHAR", "DOUBLE", "LONG", "SHORT"]
 
 
-class CheckFuncDeclaration(Rule):
-    def __init__(self):
-        super().__init__()
-        self.depends_on = (
-            "IsFuncDeclaration",
-            "IsFuncPrototype",
-            "IsUserDefinedType",
-        )
+class CheckFuncDeclaration(Rule, Check):
+    depends_on = (
+        "IsFuncDeclaration",
+        "IsFuncPrototype",
+        "IsUserDefinedType",
+    )
 
     def run(self, context):
         """

--- a/norminette/rules/check_func_spacing.py
+++ b/norminette/rules/check_func_spacing.py
@@ -1,4 +1,4 @@
-from norminette.rules import Rule
+from norminette.rules import Rule, Check
 
 whitespaces = ["SPACE", "TAB", "NEWLINE"]
 
@@ -13,10 +13,10 @@ sign_specifiers = ["SIGNED", "UNSIGNED"]
 arg_separator = ["COMMA", "CLOSING_PARENTHESIS"]
 
 
-class CheckFuncSpacing(Rule):
-    def __init__(self):
-        super().__init__()
-        self.depends_on = ["IsFuncDeclaration"]
+class CheckFuncSpacing(Rule, Check):
+    depends_on = (
+        "IsFuncDeclaration",
+    )
 
     def run(self, context):
         """

--- a/norminette/rules/check_functions_count.py
+++ b/norminette/rules/check_functions_count.py
@@ -1,10 +1,10 @@
-from norminette.rules import Rule
+from norminette.rules import Rule, Check
 
 
-class CheckFunctionsCount(Rule):
-    def __init__(self):
-        super().__init__()
-        self.depends_on = ["IsFuncDeclaration"]
+class CheckFunctionsCount(Rule, Check):
+    depends_on = (
+        "IsFuncDeclaration",
+    )
 
     def run(self, context):
         """

--- a/norminette/rules/check_general_spacing.py
+++ b/norminette/rules/check_general_spacing.py
@@ -1,16 +1,14 @@
-from norminette.rules import Rule
+from norminette.rules import Rule, Check
 
 
-class CheckGeneralSpacing(Rule):
-    def __init__(self):
-        super().__init__()
-        self.depends_on = [
-            "IsDeclaration",
-            "IsControlStatement",
-            "IsExpressionStatement",
-            "IsAssignation",
-            "IsFunctionCall",
-        ]
+class CheckGeneralSpacing(Rule, Check):
+    depends_on = (
+        "IsDeclaration",
+        "IsControlStatement",
+        "IsExpressionStatement",
+        "IsAssignation",
+        "IsFunctionCall",
+    )
 
     def run(self, context):
         """

--- a/norminette/rules/check_global_naming.py
+++ b/norminette/rules/check_global_naming.py
@@ -1,4 +1,4 @@
-from norminette.rules import Rule
+from norminette.rules import Rule, Check
 
 types = [
     "INT",
@@ -22,10 +22,10 @@ types = [
 ]
 
 
-class CheckGlobalNaming(Rule):
-    def __init__(self):
-        super().__init__()
-        self.depends_on = ["IsVarDeclaration"]
+class CheckGlobalNaming(Rule, Check):
+    depends_on = (
+        "IsVarDeclaration",
+    )
 
     def run(self, context):
         """

--- a/norminette/rules/check_header.py
+++ b/norminette/rules/check_header.py
@@ -1,12 +1,8 @@
-from norminette.rules import Rule
+from norminette.rules import Rule, Check
 import re
 
 
-class CheckHeader(Rule):
-    def __init__(self):
-        super().__init__()
-        self.depends_on = []
-
+class CheckHeader(Rule, Check):
     def parse_header(self, context):
         if context.check_token(0, "MULT_COMMENT") is False:
             context.new_error("INVALID_HEADER", context.peek_token(0))

--- a/norminette/rules/check_identifier_name.py
+++ b/norminette/rules/check_identifier_name.py
@@ -1,17 +1,13 @@
 import string
 
-from norminette.rules import Rule
+from norminette.rules import Rule, Check
 from norminette.scope import GlobalScope, UserDefinedType
 
 
 assigns = ["ASSIGN"]
 
 
-class CheckIdentifierName(Rule):
-    def __init__(self):
-        super().__init__()
-        self.depends_on = []
-
+class CheckIdentifierName(Rule, Check):
     def run(self, context):
         """
         Function can only be declared in the global scope

--- a/norminette/rules/check_in_header.py
+++ b/norminette/rules/check_in_header.py
@@ -1,4 +1,4 @@
-from norminette.rules import Rule
+from norminette.rules import Rule, Check
 
 
 allowed_in_header = [
@@ -20,20 +20,18 @@ must_be_within_define = [
 ]
 
 
-class CheckInHeader(Rule):
-    def __init__(self):
-        super().__init__()
-        self.depends_on = [
-            "IsVarDeclaration",
-            "IsUserDefinedType",
-            "IsPreprocessorStatement",
-            "IsEmptyLine",
-            "IsBlockStart",
-            "IsBlockEnd",
-            "IsComment",
-            "IsEndOfLine",
-            "IsFuncPrototype",
-        ]
+class CheckInHeader(Rule, Check):
+    depends_on = (
+        "IsVarDeclaration",
+        "IsUserDefinedType",
+        "IsPreprocessorStatement",
+        "IsEmptyLine",
+        "IsBlockStart",
+        "IsBlockEnd",
+        "IsComment",
+        "IsEndOfLine",
+        "IsFuncPrototype",
+    )
 
     def run(self, context):
         """

--- a/norminette/rules/check_label.py
+++ b/norminette/rules/check_label.py
@@ -1,11 +1,7 @@
-from norminette.rules import Rule
+from norminette.rules import Rule, Check
 
 
-class CheckLabel(Rule):
-    def __init__(self):
-        super().__init__()
-        self.depends_on = []
-
+class CheckLabel(Rule, Check):
     def run(self, context):
         """
         Goto and labels are forbidden

--- a/norminette/rules/check_line_count.py
+++ b/norminette/rules/check_line_count.py
@@ -1,12 +1,8 @@
 from norminette.context import GlobalScope
-from norminette.rules import Rule
+from norminette.rules import Rule, Check
 
 
-class CheckLineCount(Rule):
-    def __init__(self):
-        super().__init__()
-        self.depends_on = []
-
+class CheckLineCount(Rule, Check):
     def run(self, context):
         """
         Each function can only have 25 lines between its opening and closing brackets

--- a/norminette/rules/check_line_indent.py
+++ b/norminette/rules/check_line_indent.py
@@ -1,12 +1,8 @@
-from norminette.rules import Rule
+from norminette.rules import Rule, Check
 from norminette.scope import GlobalScope
 
 
-class CheckLineIndent(Rule):
-    def __init__(self):
-        super().__init__()
-        self.depends_on = []
-
+class CheckLineIndent(Rule, Check):
     def run(self, context):
         """
         Each new scope (function, control structure, struct/enum type declaration) adds a tab to the general indentation

--- a/norminette/rules/check_line_len.py
+++ b/norminette/rules/check_line_len.py
@@ -1,11 +1,7 @@
-from norminette.rules import Rule
+from norminette.rules import Rule, Check
 
 
-class CheckLineLen(Rule):
-    def __init__(self):
-        super().__init__()
-        self.depends_on = []
-
+class CheckLineLen(Rule, Check):
     def run(self, context):
         """
         Lines must not be over 80 characters long

--- a/norminette/rules/check_many_instructions.py
+++ b/norminette/rules/check_many_instructions.py
@@ -1,20 +1,18 @@
-from norminette.rules import Rule
+from norminette.rules import Rule, Check
 
 
-class CheckManyInstructions(Rule):
-    def __init__(self):
-        super().__init__()
-        self.depends_on = [
-            "IsAssignation",
-            "IsBlockEnd",
-            "IsControlStatement",
-            "IsExpressionStatement",
-            "IsFuncDeclaration",
-            "IsFuncPrototype",
-            "IsUserDefinedType",
-            "IsVarDeclaration",
-            "IsFunctionCall",
-        ]
+class CheckManyInstructions(Rule, Check):
+    depends_on = (
+        "IsAssignation",
+        "IsBlockEnd",
+        "IsControlStatement",
+        "IsExpressionStatement",
+        "IsFuncDeclaration",
+        "IsFuncPrototype",
+        "IsUserDefinedType",
+        "IsVarDeclaration",
+        "IsFunctionCall",
+    )
 
     def run(self, context):
         """

--- a/norminette/rules/check_nest_line_indent.py
+++ b/norminette/rules/check_nest_line_indent.py
@@ -1,4 +1,4 @@
-from norminette.rules import Rule
+from norminette.rules import Rule, Check
 
 
 operators = [
@@ -39,14 +39,12 @@ operators = [
 nest_kw = ["RPARENTHESIS", "LPARENTHESIS", "NEWLINE"]
 
 
-class CheckNestLineIndent(Rule):
-    def __init__(self):
-        super().__init__()
-        self.depends_on = [
-            "IsControlStatement",
-            "IsExpressionStatement",
-            "IsDeclaration",
-        ]
+class CheckNestLineIndent(Rule, Check):
+    depends_on = (
+        "IsControlStatement",
+        "IsExpressionStatement",
+        "IsDeclaration",
+    )
 
     def find_nest_content(self, context, nest, i):
         expected = context.scope.indent + nest

--- a/norminette/rules/check_newline_indent.py
+++ b/norminette/rules/check_newline_indent.py
@@ -1,10 +1,8 @@
-from norminette.rules import Rule
+from norminette.rules import Rule, Check
 
 
-class CheckNewlineIndent(Rule):
-    def __init__(self):
-        super().__init__()
-        self.depends_on = [
+class CheckNewlineIndent(Rule, Check):
+    depends_on = [
             "IsDeclaration",
             "IsAssignation",
             "IsCast",

--- a/norminette/rules/check_operators_spacing.py
+++ b/norminette/rules/check_operators_spacing.py
@@ -1,4 +1,4 @@
-from norminette.rules import Rule
+from norminette.rules import Rule, Check
 
 operators = [
     "RIGHT_ASSIGN",
@@ -138,20 +138,17 @@ right_auth = []
 whitespaces = ["NEWLINE", "SPACE", "TAB"]
 
 
-class CheckOperatorsSpacing(Rule):
-    def __init__(self):
-        super().__init__()
-        self.depends_on = [
-            "IsFuncDeclaration",
-            "IsFuncPrototype",
-            "IsExpressionStatement",
-            "IsAssignation",
-            "IsControlStatement",
-            "IsVarDeclaration",
-            "IsFunctionCall",
-            "IsDeclaration",
-        ]
-        self.last_seen_tkn = None
+class CheckOperatorsSpacing(Rule, Check):
+    depends_on = (
+        "IsFuncDeclaration",
+        "IsFuncPrototype",
+        "IsExpressionStatement",
+        "IsAssignation",
+        "IsControlStatement",
+        "IsVarDeclaration",
+        "IsFunctionCall",
+        "IsDeclaration",
+    )
 
     def check_prefix(self, context, pos):
         if pos > 0 and context.check_token(pos, ["TAB", "SPACE"]):
@@ -472,7 +469,6 @@ class CheckOperatorsSpacing(Rule):
         some must be only followed by a space,
         and the rest must be preceded and followed by a space.
         """
-        self.last_seen_tkn = None
         i = 0
         while i < len(context.tokens[: context.tkn_scope]):
             if context.check_token(i, ["MULT", "BWISE_AND"]) is True:
@@ -504,7 +500,5 @@ class CheckOperatorsSpacing(Rule):
                 self.check_suffix(context, i)
             elif context.check_token(i, p_operators) is True:
                 self.check_prefix(context, i)
-            if context.check_token(i, whitespaces) is False:
-                self.last_seen_tkn = context.peek_token(i)
             i += 1
         return False, 0

--- a/norminette/rules/check_preprocessor_define.py
+++ b/norminette/rules/check_preprocessor_define.py
@@ -1,10 +1,10 @@
-from norminette.rules import Rule
+from norminette.rules import Rule, Check
 
 
-class CheckPreprocessorDefine(Rule):
-    def __init__(self):
-        super().__init__()
-        self.depends_on = ["IsPreprocessorStatement"]
+class CheckPreprocessorDefine(Rule, Check):
+    depends_on = (
+        "IsPreprocessorStatement",
+    )
 
     def run(self, context):
         """

--- a/norminette/rules/check_preprocessor_include.py
+++ b/norminette/rules/check_preprocessor_include.py
@@ -1,13 +1,13 @@
 import os.path
 import itertools
 
-from norminette.rules import Rule
+from norminette.rules import Rule, Check
 
 
-class CheckPreprocessorInclude(Rule):
-    def __init__(self):
-        super().__init__()
-        self.depends_on = ["IsPreprocessorStatement"]
+class CheckPreprocessorInclude(Rule, Check):
+    depends_on = (
+        "IsPreprocessorStatement",
+    )
 
     def run(self, context):
         """

--- a/norminette/rules/check_preprocessor_indent.py
+++ b/norminette/rules/check_preprocessor_indent.py
@@ -1,4 +1,4 @@
-from norminette.rules import Rule
+from norminette.rules import Rule, Check
 from norminette.scope import GlobalScope
 
 ARGUMENTED_PREPROCESSORS = (
@@ -16,10 +16,10 @@ ARGUMENTED_PREPROCESSORS = (
 )
 
 
-class CheckPreprocessorIndent(Rule):
-    def __init__(self):
-        super().__init__()
-        self.depends_on = ["IsPreprocessorStatement"]
+class CheckPreprocessorIndent(Rule, Check):
+    depends_on = (
+        "IsPreprocessorStatement",
+    )
 
     def run(self, context):
         """

--- a/norminette/rules/check_preprocessor_protection.py
+++ b/norminette/rules/check_preprocessor_protection.py
@@ -1,15 +1,13 @@
 import itertools
 from pathlib import Path
 
-from norminette.rules import Rule
+from norminette.rules import Rule, Check
 
 
-class CheckPreprocessorProtection(Rule):
-    def __init__(self):
-        super().__init__()
-        self.depends_on = [
-            "IsPreprocessorStatement",
-        ]
+class CheckPreprocessorProtection(Rule, Check):
+    depends_on = (
+        "IsPreprocessorStatement",
+    )
 
     def run(self, context):
         """

--- a/norminette/rules/check_prototype_indent.py
+++ b/norminette/rules/check_prototype_indent.py
@@ -1,6 +1,6 @@
 import math
 
-from norminette.rules import Rule
+from norminette.rules import Rule, Check
 
 keywords = [
     # C reserved keywords #
@@ -41,10 +41,10 @@ keywords = [
 eol = ["SEMI_COLON", "LPARENTHESIS"]
 
 
-class CheckPrototypeIndent(Rule):
-    def __init__(self):
-        super().__init__()
-        self.depends_on = ["IsFuncPrototype"]
+class CheckPrototypeIndent(Rule, Check):
+    depends_on = (
+        "IsFuncPrototype",
+    )
 
     def run(self, context):
         """

--- a/norminette/rules/check_spacing.py
+++ b/norminette/rules/check_spacing.py
@@ -1,11 +1,7 @@
-from norminette.rules import Rule
+from norminette.rules import Rule, Check
 
 
-class CheckSpacing(Rule):
-    def __init__(self):
-        super().__init__()
-        self.depends_on = []
-
+class CheckSpacing(Rule, Check):
     def run(self, context):
         """
         Indentation (except for preprocessors) must be done with tabs

--- a/norminette/rules/check_struct_naming.py
+++ b/norminette/rules/check_struct_naming.py
@@ -1,4 +1,4 @@
-from norminette.rules import Rule
+from norminette.rules import Rule, Check
 
 types = [
     "STRUCT",
@@ -7,18 +7,16 @@ types = [
 ]
 
 
-class CheckStructNaming(Rule):
-    def __init__(self):
-        super().__init__()
-        self.depends_on = ["IsUserDefinedType"]
-        self.__i = 0
+class CheckStructNaming(Rule, Check):
+    depends_on = (
+        "IsUserDefinedType",
+    )
 
     def run(self, context):
         """
         Rewritten elsewhere
         """
         return False, 0
-        self.__i += 1
         i = 0
         i = context.skip_ws(i)
         while context.check_token(i, types) is False:

--- a/norminette/rules/check_ternary.py
+++ b/norminette/rules/check_ternary.py
@@ -1,11 +1,7 @@
-from norminette.rules import Rule
+from norminette.rules import Rule, Check
 
 
-class CheckTernary(Rule):
-    def __init__(self):
-        super().__init__()
-        self.depends_on = []
-
+class CheckTernary(Rule, Check):
     def run(self, context):
         """
         Ternaries are forbidden

--- a/norminette/rules/check_utype_declaration.py
+++ b/norminette/rules/check_utype_declaration.py
@@ -1,5 +1,5 @@
 from norminette.exceptions import CParsingError
-from norminette.rules import Rule
+from norminette.rules import Rule, Check
 
 types = [
     "STRUCT",
@@ -22,10 +22,10 @@ types = [
 utypes = ["STRUCT", "ENUM", "UNION"]
 
 
-class CheckUtypeDeclaration(Rule):
-    def __init__(self):
-        super().__init__()
-        self.depends_on = ["IsUserDefinedType"]
+class CheckUtypeDeclaration(Rule, Check):
+    depends_on = (
+        "IsUserDefinedType",
+    )
 
     def run(self, context):
         """

--- a/norminette/rules/check_variable_declaration.py
+++ b/norminette/rules/check_variable_declaration.py
@@ -1,4 +1,4 @@
-from norminette.rules import Rule
+from norminette.rules import Rule, Check
 
 assigns = [
     "RIGHT_ASSIGN",
@@ -15,10 +15,10 @@ assigns = [
 ]
 
 
-class CheckVariableDeclaration(Rule):
-    def __init__(self):
-        super().__init__()
-        self.depends_on = ["IsVarDeclaration"]
+class CheckVariableDeclaration(Rule, Check):
+    depends_on = (
+        "IsVarDeclaration",
+    )
 
     def run(self, context):
         """

--- a/norminette/rules/check_variable_indent.py
+++ b/norminette/rules/check_variable_indent.py
@@ -1,7 +1,7 @@
 import math
 import string
 
-from norminette.rules import Rule
+from norminette.rules import Rule, Check
 
 
 keywords = [
@@ -58,10 +58,10 @@ assigns_or_eol = [
 ]
 
 
-class CheckVariableIndent(Rule):
-    def __init__(self):
-        super().__init__()
-        self.depends_on = ["IsVarDeclaration"]
+class CheckVariableIndent(Rule, Check):
+    depends_on = (
+        "IsVarDeclaration",
+    )
 
     def check_tabs(self, context):
         i = 0

--- a/norminette/rules/is_ambiguous_declaration.py
+++ b/norminette/rules/is_ambiguous_declaration.py
@@ -1,15 +1,10 @@
-from norminette.rules import PrimaryRule
+from norminette.rules import Primary, Rule
 
 cs_keywords = ["DO", "WHILE", "FOR", "IF", "ELSE", "SWITCH", "CASE", "DEFAULT"]
 whitespaces = ["TAB", "SPACE", "NEWLINE"]
 
 
-class IsAmbiguousDeclaration(PrimaryRule):
-    def __init__(self):
-        super().__init__()
-        self.priority = 0
-        self.scope = []
-
+class IsAmbiguousDeclaration(Primary, Rule, priority=0):
     def run(self, context):
         """
         Catches missing semi-colon or other various missing stuff. Dev feature

--- a/norminette/rules/is_assignation.py
+++ b/norminette/rules/is_assignation.py
@@ -1,4 +1,4 @@
-from norminette.rules import PrimaryRule
+from norminette.rules import Rule, Primary
 
 assign_ops = [
     "RIGHT_ASSIGN",
@@ -60,13 +60,7 @@ op = [
 ws = ["SPACE", "TAB", "NEWLINE"]
 
 
-class IsAssignation(PrimaryRule):
-    def __init__(self):
-        super().__init__()
-        self.primary = True
-        self.priority = 20
-        self.scope = []
-
+class IsAssignation(Rule, Primary, priority=20):
     def check_identifier(self, context, pos):
         i = pos
         while context.check_token(

--- a/norminette/rules/is_block_end.py
+++ b/norminette/rules/is_block_end.py
@@ -2,15 +2,10 @@ from norminette.context import ControlStructure
 from norminette.scope import UserDefinedEnum
 from norminette.scope import UserDefinedType
 from norminette.scope import VariableAssignation
-from norminette.rules import PrimaryRule
+from norminette.rules import Rule, Primary
 
 
-class IsBlockEnd(PrimaryRule):
-    def __init__(self):
-        super().__init__()
-        self.priority = 54
-        self.scope = []
-
+class IsBlockEnd(Rule, Primary, priority=54):
     def check_udef_typedef(self, context, pos):
         i = context.skip_ws(pos)
         if context.check_token(i, "IDENTIFIER") is False:

--- a/norminette/rules/is_block_start.py
+++ b/norminette/rules/is_block_start.py
@@ -1,20 +1,17 @@
 from norminette.context import ControlStructure
-from norminette.rules import PrimaryRule
+from norminette.rules import Rule, Primary
 from norminette.scope import GlobalScope, UserDefinedEnum, Function, UserDefinedType, VariableAssignation
 
 
-class IsBlockStart(PrimaryRule):
-    def __init__(self):
-        super().__init__()
-        self.priority = 55
-        self.scope = [
-            Function,
-            UserDefinedType,
-            VariableAssignation,
-            ControlStructure,
-            UserDefinedEnum,
-            GlobalScope,
-        ]
+class IsBlockStart(Rule, Primary, priority=55):
+    scope = (
+        Function,
+        UserDefinedType,
+        VariableAssignation,
+        ControlStructure,
+        UserDefinedEnum,
+        GlobalScope,
+    )
 
     def run(self, context):
         """

--- a/norminette/rules/is_cast.py
+++ b/norminette/rules/is_cast.py
@@ -1,4 +1,4 @@
-from norminette.rules import PrimaryRule
+from norminette.rules import Rule, Primary
 
 types = [
     "CHAR",
@@ -37,13 +37,7 @@ op = [
 ws = ["SPACE", "TAB", "NEWLINE"]
 
 
-class IsCast(PrimaryRule):
-    def __init__(self):
-        super().__init__()
-        self.primary = True
-        self.priority = 15
-        self.scope = []
-
+class IsCast(Rule, Primary, priority=15):
     def run(self, context):
         """
         Catches all casts instructions

--- a/norminette/rules/is_comment.py
+++ b/norminette/rules/is_comment.py
@@ -1,18 +1,14 @@
-from norminette.rules import PrimaryRule
+from norminette.rules import Rule, Primary
 
 
-class IsComment(PrimaryRule):
-    def __init__(self):
-        super().__init__()
-        self.priority = 90
-        self.scope = []
-
+class IsComment(Rule, Primary, priority=90):
     def run(self, context):
         """
         Catches comments tokens
         """
         i = context.skip_ws(0)
         if context.check_token(i, ["MULT_COMMENT", "COMMENT"]) is True:
+            self.comment = context.peek_token(i)
             i += 1
             i = context.eol(i)
             return True, i

--- a/norminette/rules/is_control_statement.py
+++ b/norminette/rules/is_control_statement.py
@@ -1,7 +1,7 @@
 from norminette.context import ControlStructure
 from norminette.scope import Function
 from norminette.context import GlobalScope
-from norminette.rules import PrimaryRule
+from norminette.rules import Rule, Primary
 
 cs_keywords = [
     "DO",
@@ -17,11 +17,12 @@ cs_keywords = [
 whitespaces = ["TAB", "SPACE", "NEWLINE"]
 
 
-class IsControlStatement(PrimaryRule):
-    def __init__(self):
-        super().__init__()
-        self.priority = 65
-        self.scope = [Function, ControlStructure, GlobalScope]
+class IsControlStatement(Rule, Primary, priority=65):
+    scope = (
+        Function,
+        ControlStructure,
+        GlobalScope,
+    )
 
     def run(self, context):
         """

--- a/norminette/rules/is_declaration.py
+++ b/norminette/rules/is_declaration.py
@@ -1,12 +1,7 @@
-from norminette.rules import PrimaryRule
+from norminette.rules import Rule, Primary
 
 
-class IsDeclaration(PrimaryRule):
-    def __init__(self):
-        super().__init__()
-        self.priority = 5
-        self.scope = []
-
+class IsDeclaration(Rule, Primary, priority=5):
     def run(self, context):
         # return False, 0
         i = context.skip_ws(0, nl=False)

--- a/norminette/rules/is_empty_line.py
+++ b/norminette/rules/is_empty_line.py
@@ -1,15 +1,10 @@
-from norminette.rules import PrimaryRule
+from norminette.rules import Rule, Primary
 
 cs_keywords = ["DO", "WHILE", "FOR", "IF", "ELSE", "SWITCH"]
 whitespaces = ["TAB", "SPACE", "NEWLINE"]
 
 
-class IsEmptyLine(PrimaryRule):
-    def __init__(self):
-        super().__init__()
-        self.priority = 70
-        self.scope = []
-
+class IsEmptyLine(Rule, Primary, priority=70):
     def run(self, context):
         """
         Catches empty line

--- a/norminette/rules/is_enum_var_decl.py
+++ b/norminette/rules/is_enum_var_decl.py
@@ -1,4 +1,4 @@
-from norminette.rules import PrimaryRule
+from norminette.rules import Rule, Primary
 from norminette.scope import UserDefinedEnum
 
 
@@ -6,11 +6,10 @@ lbrackets = ["LBRACE", "LPARENTHESIS", "LBRACKET"]
 rbrackets = ["RBRACE", "RPARENTHESIS", "RBRACKET"]
 
 
-class IsEnumVarDecl(PrimaryRule):
-    def __init__(self):
-        super().__init__()
-        self.priority = 30
-        self.scope = [UserDefinedEnum]
+class IsEnumVarDecl(Rule, Primary, priority=30):
+    scope = (
+        UserDefinedEnum,
+    )
 
     def assignment_right_side(self, context, pos):
         sep = ["COMMA", "ASSIGN", "NEWLINE"]

--- a/norminette/rules/is_expression_statement.py
+++ b/norminette/rules/is_expression_statement.py
@@ -1,7 +1,7 @@
 from norminette.context import ControlStructure
 from norminette.scope import Function
 from norminette.exceptions import CParsingError
-from norminette.rules import PrimaryRule
+from norminette.rules import Rule, Primary
 
 keywords = ["BREAK", "CONTINUE", "GOTO", "RETURN"]
 
@@ -18,11 +18,11 @@ operators = [
 ws = ["SPACE", "TAB", "NEWLINE"]
 
 
-class IsExpressionStatement(PrimaryRule):
-    def __init__(self):
-        super().__init__()
-        self.priority = 25
-        self.scope = [Function, ControlStructure]
+class IsExpressionStatement(Rule, Primary, priority=25):
+    scope = (
+        Function,
+        ControlStructure,
+    )
 
     def check_reserved_keywords(self, context, pos):
         if context.check_token(pos, keywords) is False:

--- a/norminette/rules/is_func_declaration.py
+++ b/norminette/rules/is_func_declaration.py
@@ -1,6 +1,6 @@
 from norminette.scope import Function
 from norminette.context import GlobalScope
-from norminette.rules import PrimaryRule
+from norminette.rules import Rule, Primary
 
 
 whitespaces = ["SPACE", "TAB"]
@@ -47,11 +47,10 @@ type_identifier = [
 ]
 
 
-class IsFuncDeclaration(PrimaryRule):
-    def __init__(self):
-        super().__init__()
-        self.priority = 81
-        self.scope = [GlobalScope]
+class IsFuncDeclaration(Rule, Primary, priority=81):
+    scope = (
+        GlobalScope,
+    )
 
     def check_args(self, context, pos):
         i = context.skip_ws(pos, nl=True)

--- a/norminette/rules/is_func_prototype.py
+++ b/norminette/rules/is_func_prototype.py
@@ -1,6 +1,6 @@
 from norminette.context import GlobalScope
 from norminette.scope import UserDefinedType
-from norminette.rules import PrimaryRule
+from norminette.rules import Rule, Primary
 
 whitespaces = ["SPACE", "TAB"]
 assigns = [
@@ -44,11 +44,10 @@ type_identifier = [
 ]
 
 
-class IsFuncPrototype(PrimaryRule):
-    def __init__(self):
-        super().__init__()
-        self.priority = 82
-        self.scope = [GlobalScope]
+class IsFuncPrototype(Rule, Primary, priority=82):
+    scope = (
+        GlobalScope,
+    )
 
     def check_args(self, context, pos):
         i = context.skip_ws(pos)

--- a/norminette/rules/is_function_call.py
+++ b/norminette/rules/is_function_call.py
@@ -1,4 +1,4 @@
-from norminette.rules import PrimaryRule
+from norminette.rules import Rule, Primary
 from norminette.lexer.dictionary import keywords
 
 condition_ops = [
@@ -82,13 +82,7 @@ op = [
 ws = ["SPACE", "TAB", "NEWLINE"]
 
 
-class IsFunctionCall(PrimaryRule):
-    def __init__(self):
-        super().__init__()
-        self.primary = True
-        self.priority = 80
-        self.scope = []
-
+class IsFunctionCall(Rule, Primary, priority=80):
     def run(self, context):
         """
         Catches function calls when it's in an assignation

--- a/norminette/rules/is_label.py
+++ b/norminette/rules/is_label.py
@@ -1,11 +1,7 @@
-from norminette.rules import PrimaryRule
+from norminette.rules import Rule, Primary
 
 
-class IsLabel(PrimaryRule):
-    def __init__(self):
-        super().__init__()
-        self.priority = 10
-
+class IsLabel(Rule, Primary, priority=10):
     def run(self, context):
         """
         Catches label and raises norm error whenever

--- a/norminette/rules/is_preprocessor_statement.py
+++ b/norminette/rules/is_preprocessor_statement.py
@@ -1,7 +1,7 @@
 import sys
 import contextlib
 
-from norminette.rules import PrimaryRule
+from norminette.rules import Rule, Primary
 from norminette.exceptions import CParsingError
 from norminette.context import Macro
 
@@ -56,12 +56,7 @@ def recursion_limit(limit):
     sys.setrecursionlimit(old_limit)
 
 
-class IsPreprocessorStatement(PrimaryRule):
-    def __init__(self):
-        super().__init__()
-        self.priority = 100
-        self.scope = []
-
+class IsPreprocessorStatement(Rule, Primary, priority=100):
     def run(self, context):
         """
         Catches any kind of preprocessor statements

--- a/norminette/rules/is_ternary.py
+++ b/norminette/rules/is_ternary.py
@@ -1,12 +1,7 @@
-from norminette.rules import PrimaryRule
+from norminette.rules import Rule, Primary
 
 
-class IsTernary(PrimaryRule):
-    def __init__(self):
-        super().__init__()
-        self.priority = 53
-        self.scope = []
-
+class IsTernary(Rule, Primary, priority=53):
     def run(self, context):
         """
         Catches ternaries and raises an error

--- a/norminette/rules/is_user_defined_type.py
+++ b/norminette/rules/is_user_defined_type.py
@@ -1,14 +1,14 @@
-from norminette.rules import PrimaryRule
+from norminette.rules import Rule, Primary
 from norminette.scope import UserDefinedType, GlobalScope, UserDefinedEnum
 
 utypes = ["TYPEDEF", "UNION", "STRUCT", "ENUM"]
 
 
-class IsUserDefinedType(PrimaryRule):
-    def __init__(self):
-        super().__init__()
-        self.priority = 45
-        self.scope = [GlobalScope, UserDefinedType]
+class IsUserDefinedType(Rule, Primary, priority=45):
+    scope = (
+        GlobalScope,
+        UserDefinedType,
+    )
 
     def typedef(self, context, pos):
         i = context.skip_ws(pos)

--- a/norminette/rules/is_var_declaration.py
+++ b/norminette/rules/is_var_declaration.py
@@ -2,7 +2,7 @@ from norminette.context import ControlStructure
 from norminette.scope import Function
 from norminette.context import GlobalScope
 from norminette.scope import UserDefinedType
-from norminette.rules import PrimaryRule
+from norminette.rules import Rule, Primary
 
 lbrackets = ["LBRACE", "LPARENTHESIS", "LBRACKET"]
 rbrackets = ["RBRACE", "RPARENTHESIS", "RBRACKET"]
@@ -35,11 +35,13 @@ type_specifiers = [
 ]
 
 
-class IsVarDeclaration(PrimaryRule):
-    def __init__(self):
-        super().__init__()
-        self.priority = 75
-        self.scope = [GlobalScope, UserDefinedType, Function, ControlStructure]
+class IsVarDeclaration(Rule, Primary, priority=75):
+    scope = (
+        GlobalScope,
+        UserDefinedType,
+        Function,
+        ControlStructure,
+    )
 
     def assignment_right_side(self, context, pos):
         sep = ["COMMA", "SEMI_COLON", "ASSIGN"]

--- a/norminette/rules/rule.py
+++ b/norminette/rules/rule.py
@@ -1,29 +1,89 @@
+from typing import Tuple
+
+from norminette.context import Context
+
+
 class Rule:
-    def __init__(self):
-        self.name = type(self).__name__
-        self.depends_on = []
-        self.primary = False
+    __slots__ = ()
 
-    def register(self, registry):
-        if self.depends_on == []:
-            if "all" in registry.dependencies:
-                registry.dependencies["all"].append(self.name)
-            else:
-                registry.dependencies["all"] = [self.name]
+    def __new__(cls, context: Context, *args, **kwargs):
+        cls.context = context
+        cls.name = cls.__name__
 
-        for rule in self.depends_on:
-            if rule in registry.dependencies:
-                registry.dependencies[rule].append(self.name)
-            else:
-                registry.dependencies[rule] = [self.name]
+        return super().__new__(cls, *args, **kwargs)
+
+    def __repr__(self) -> str:
+        return self.name
+
+    def __hash__(self) -> int:
+        return hash(self.name)
+
+    def __eq__(self, value) -> bool:
+        if isinstance(value, str):
+            return self.name == value
+        if hasattr(value, "name"):
+            return self.name == value.name
+        return super().__eq__(value)
+
+    def __ne__(self, value) -> bool:
+        return not (self == value)
 
 
-class PrimaryRule(Rule):
-    def __init__(self):
-        super().__init__()
-        self.primary = True
-        self.priority = 0
-        self.scope = []
+class Check:
+    __slots__ = ()
 
-    def run(self, context):
+    depends_on: Tuple[str, ...]
+
+    runs_on_start: bool
+    runs_on_rule: bool
+    runs_on_end: bool
+
+    def __init_subclass__(cls, **kwargs):
+        if not hasattr(cls, "depends_on"):
+            cls.depends_on = ()
+        cls.runs_on_start = kwargs.pop("runs_on_start", getattr(cls, "runs_on_start", False))
+        cls.runs_on_rule = kwargs.pop("runs_on_rule", getattr(cls, "runs_on_rule", not cls.depends_on))
+        cls.runs_on_end = kwargs.pop("runs_on_end", getattr(cls, "runs_on_end", False))
+
+    @classmethod
+    def register(cls, registry):
+        for rule in cls.depends_on:
+            registry.dependencies[rule].append(cls)
+        if cls.runs_on_start:
+            registry.dependencies["_start"].append(cls)
+        if cls.runs_on_rule:
+            registry.dependencies["_rule"].append(cls)
+        if cls.runs_on_end:
+            registry.dependencies["_end"].append(cls)
+
+    def is_starting(self):
+        """Returns if this `Check` is being run before `Primary`.
+
+        It is only called if `runs_on_start` is set to `True`.
+        """
+        return self.context.state == "starting"  # type: ignore
+
+    def is_ending(self):
+        """Returns if this `Check` is being run after all rules.
+
+        It is only called if `runs_on_end` is set to `True`.
+        """
+        return self.context.state == "ending"  # type: ignore
+
+    def run(self, context: Context) -> None:
+        return
+
+
+class Primary:
+    __slots__ = ()
+
+    priority: int
+    scope: Tuple[str, ...]
+
+    def __init_subclass__(cls, **kwargs):
+        cls.priority = kwargs.pop("priority", 0)
+        if not hasattr(cls, "scope"):
+            cls.scope = ()
+
+    def run(self, context: Context) -> Tuple[bool, int]:
         return False, 0

--- a/norminette/scope.py
+++ b/norminette/scope.py
@@ -38,6 +38,18 @@ class Scope:
         # print (f"{self.name} -> {self.parent.name}")
         return self.parent
 
+    def __eq__(self, value) -> bool:
+        if isinstance(value, str):
+            return self.name == value
+        if issubclass(value, Scope):
+            return self.name == value.__name__
+        if hasattr(value, "name"):
+            return self.name == value.name
+        return super().__eq__(value)
+
+    def __ne__(self, value) -> bool:
+        return not (self == value)
+
     def get_outer(self):
         """
         Allows to peek to the parent scope without adding lines to


### PR DESCRIPTION
Although norminette only does lexical analysis, we are not able to do syntax analysis that does not force a stop in norminette, we can use [is_preprocessor_statement.py](https://github.com/NiumXp/norminette/blob/83867a6c2af1f176e380ec2a24516ac15a522229/norminette/rules/is_preprocessor_statement.py) as a good example of this, we raise a lot of `CParsingError` when something is not syntactically correct instead of marking the pre-processor statement as "bad" or "malformed" and creating an error with `new_error` to report this error.

To add "rich" information in `context.history` I store instances of `Rule`s instead of their names inside it. If in `IsComment` primary rule we store the `COMMENT` and `MULT_COMMENT` tokens in their instance, we can get the 42 header source with something like this:
```py
def run(self, context):
    _header_lines = 11
    for index, record in enumerate(context.history):
        if record != "IsComment":
            continue
        records = record.history[index:index+_header_lines]
        if not all(it == "IsComment" for it in records):
            continue
        comments = tuple(it.comment for it in records)
        if not all(it.type == "MULT_COMMENT" for it in comments):
            continue
        header = '\n'.join(it.value for it in comments)
        if not self.is_valid_header(header):
            context.new_error("MISSING_HEADER", comments[0])
        elif index != 0:  # Header is not on top of file
            context.new_error("NOTONTOP_HEADER", comments[0])
```
Storing the comments tokens in history, we are able to say if the header is or not in top of file, if header is missing or if is header invalid in an easier way.

Some rules need to be run only once, like `CheckHeader`, `CheckLineCount`, `CheckLineLen`, `CheckSpacing`, etc. and to its case, I added a way to be able run a `Check` rule before and after `Registry.run_rules`. An example of `CheckLineLen` now:
```py
from norminette.rules import Rule, Check


class CheckLineLen(Rule, Check):
    runs_on_rule = False  # Avoid run after an `Is*` rule
    runs_on_start = True

    def run(self, context):
        lines = context.file.source.splitlines()
        for lineno, line in enumerate(lines, start=1):
            if len(line) > 81:
                context.new_error("LINE_TOO_LONG", (lineno, 80))
```
---
This PR is just a step to improve norminette to be able fix errors like in #394 and #419. I want to make others improves like add more information in `Token` class to be able show better error messages in unexpected exceptions (reported in #411), improve `context.tokens` to be able add some helpers like `skip_type_specifier`, `skip_expression`, etc. to be easy fix problems like in #441.