### PR TITLE
Add to forbid struct in C files and in scopes that is not global

### DIFF
--- a/norminette/norm_error.py
+++ b/norminette/norm_error.py
@@ -115,6 +115,8 @@ digits or '_'",
     "ATTR_EOL": "Function attribute must be at the end of line",
     "INVALID_HEADER": "Missing or invalid 42 header",
     "INCLUDE_MISSING_SP": "Missing space between include and filename",
+    "TYPE_NOT_GLOBAL": "Enums, structs and unions need to be defined only in global scope",
+    "FORBIDDEN_STRUCT": "Struct declaration are not allowed in .c files"
 }
 
 

--- a/norminette/norm_error.py
+++ b/norminette/norm_error.py
@@ -116,7 +116,10 @@ digits or '_'",
     "INVALID_HEADER": "Missing or invalid 42 header",
     "INCLUDE_MISSING_SP": "Missing space between include and filename",
     "TYPE_NOT_GLOBAL": "Enums, structs and unions need to be defined only in global scope",
-    "FORBIDDEN_STRUCT": "Struct declaration are not allowed in .c files"
+    "FORBIDDEN_TYPEDEF": "Typedef declaration are not allowed in .c files",
+    "FORBIDDEN_STRUCT": "Struct declaration are not allowed in .c files",
+    "FORBIDDEN_UNION": "Union declaration are not allowed in .c files",
+    "FORBIDDEN_ENUM": "Enum declaration are not allowed in .c files",
 }
 
 

--- a/norminette/rules/check_utype_declaration.py
+++ b/norminette/rules/check_utype_declaration.py
@@ -38,18 +38,14 @@ class CheckUtypeDeclaration(Rule, Check):
         i = 0
         i = context.skip_ws(i)
         token = context.peek_token(i)
-        if token.type == "TYPEDEF":
-            temp = context.peek_token(context.skip_ws(i + 1))
-            if temp.type in ("STRUCT", "UNION", "ENUM"):
-                token = temp
         if context.scope.name not in ("GlobalScope", "UserDefinedType"):
             context.new_error("TYPE_NOT_GLOBAL", token)
         if (
             context.filetype == "c"
-            and token.type == "STRUCT"
-            and not any(it.type == "SEMI_COLON" for it in context.tokens[:context.tkn_scope])
+            and token.type in ("STRUCT", "UNION", "ENUM", "TYPEDEF")
+            and context.scope not in ("UserDefinedType", "UserDefinedEnum")
         ):
-            context.new_error("FORBIDDEN_STRUCT", token)
+            context.new_error(f"FORBIDDEN_{token.type}", token)
         is_td = False
         on_newline = False
         utype = None

--- a/norminette/rules/check_utype_declaration.py
+++ b/norminette/rules/check_utype_declaration.py
@@ -37,6 +37,19 @@ class CheckUtypeDeclaration(Rule, Check):
         """
         i = 0
         i = context.skip_ws(i)
+        token = context.peek_token(i)
+        if token.type == "TYPEDEF":
+            temp = context.peek_token(context.skip_ws(i + 1))
+            if temp.type in ("STRUCT", "UNION", "ENUM"):
+                token = temp
+        if context.scope.name not in ("GlobalScope", "UserDefinedType"):
+            context.new_error("TYPE_NOT_GLOBAL", token)
+        if (
+            context.filetype == "c"
+            and token.type == "STRUCT"
+            and not any(it.type == "SEMI_COLON" for it in context.tokens[:context.tkn_scope])
+        ):
+            context.new_error("FORBIDDEN_STRUCT", token)
         is_td = False
         on_newline = False
         utype = None

--- a/norminette/rules/is_user_defined_type.py
+++ b/norminette/rules/is_user_defined_type.py
@@ -1,15 +1,10 @@
 from norminette.rules import Rule, Primary
-from norminette.scope import UserDefinedType, GlobalScope, UserDefinedEnum
+from norminette.scope import UserDefinedType, UserDefinedEnum
 
 utypes = ["TYPEDEF", "UNION", "STRUCT", "ENUM"]
 
 
 class IsUserDefinedType(Rule, Primary, priority=45):
-    scope = (
-        GlobalScope,
-        UserDefinedType,
-    )
-
     def typedef(self, context, pos):
         i = context.skip_ws(pos)
         if "TYPEDEF" not in [tkn.type for tkn in context.tokens[:i]]:

--- a/tests/rules/samples/check_utype_declaration_1.c
+++ b/tests/rules/samples/check_utype_declaration_1.c
@@ -1,0 +1,34 @@
+struct
+{
+	int	a;
+};
+
+void	main(void)
+{
+	struct
+	{
+		int	b;
+	};
+}
+
+// https://github.com/42School/norminette/issues/437
+enum e_endian
+{
+	LITTLE,
+	BIG
+};
+
+enum e_endian	which_endian(void)
+{
+	union
+	{
+		unsigned char	var2[2];
+		unsigned short	var1;
+	}	u_endian;// This should be the correct indentation
+//	}					u_endian; 
+	u_endian.var1 = 1;
+	if (u_endian.var1 == u_endian.var2[0])
+		return (LITTLE);
+	else
+		return (BIG);
+}

--- a/tests/rules/samples/check_utype_declaration_1.out
+++ b/tests/rules/samples/check_utype_declaration_1.out
@@ -1,0 +1,79 @@
+[36mcheck_utype_declaration_1.c[0m - [32mIsUserDefinedType[0m In "GlobalScope" from "None" line 1":
+		<STRUCT> <NEWLINE>
+[36mcheck_utype_declaration_1.c[0m - [32mIsBlockStart[0m In "UserDefinedType" from "GlobalScope" line 2":
+		<LBRACE> <NEWLINE>
+[36mcheck_utype_declaration_1.c[0m - [32mIsVarDeclaration[0m In "UserDefinedType" from "GlobalScope" line 3":
+		<TAB> <INT> <TAB> <IDENTIFIER=a> <SEMI_COLON> <NEWLINE>
+[36mcheck_utype_declaration_1.c[0m - [32mIsBlockEnd[0m In "UserDefinedType" from "GlobalScope" line 4":
+		<RBRACE> <SEMI_COLON> <NEWLINE>
+[36mcheck_utype_declaration_1.c[0m - [32mIsEmptyLine[0m In "GlobalScope" from "None" line 5":
+		<NEWLINE>
+[36mcheck_utype_declaration_1.c[0m - [32mIsFuncDeclaration[0m In "GlobalScope" from "None" line 6":
+		<VOID> <TAB> <IDENTIFIER=main> <LPARENTHESIS> <VOID> <RPARENTHESIS> <NEWLINE>
+[36mcheck_utype_declaration_1.c[0m - [32mIsBlockStart[0m In "Function" from "GlobalScope" line 7":
+		<LBRACE> <NEWLINE>
+[36mcheck_utype_declaration_1.c[0m - [32mIsUserDefinedType[0m In "Function" from "GlobalScope" line 8":
+		<TAB> <STRUCT> <NEWLINE>
+[36mcheck_utype_declaration_1.c[0m - [32mIsBlockStart[0m In "UserDefinedType" from "Function" line 9":
+		<TAB> <LBRACE> <NEWLINE>
+[36mcheck_utype_declaration_1.c[0m - [32mIsVarDeclaration[0m In "UserDefinedType" from "Function" line 10":
+		<TAB> <TAB> <INT> <TAB> <IDENTIFIER=b> <SEMI_COLON> <NEWLINE>
+[36mcheck_utype_declaration_1.c[0m - [32mIsBlockEnd[0m In "UserDefinedType" from "Function" line 11":
+		<TAB> <RBRACE> <SEMI_COLON> <NEWLINE>
+[36mcheck_utype_declaration_1.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 12":
+		<RBRACE> <NEWLINE>
+[36mcheck_utype_declaration_1.c[0m - [32mIsEmptyLine[0m In "GlobalScope" from "None" line 13":
+		<NEWLINE>
+[36mcheck_utype_declaration_1.c[0m - [32mIsComment[0m In "GlobalScope" from "None" line 14":
+		<COMMENT=// https://github.com/42School/norminette/issues/437> <NEWLINE>
+[36mcheck_utype_declaration_1.c[0m - [32mIsUserDefinedType[0m In "GlobalScope" from "None" line 15":
+		<ENUM> <SPACE> <IDENTIFIER=e_endian> <NEWLINE>
+[36mcheck_utype_declaration_1.c[0m - [32mIsBlockStart[0m In "UserDefinedEnum" from "GlobalScope" line 16":
+		<LBRACE> <NEWLINE>
+[36mcheck_utype_declaration_1.c[0m - [32mIsEnumVarDecl[0m In "UserDefinedEnum" from "GlobalScope" line 17":
+		<TAB> <IDENTIFIER=LITTLE> <COMMA> <NEWLINE>
+[36mcheck_utype_declaration_1.c[0m - [32mIsEnumVarDecl[0m In "UserDefinedEnum" from "GlobalScope" line 18":
+		<TAB> <IDENTIFIER=BIG> <NEWLINE>
+[36mcheck_utype_declaration_1.c[0m - [32mIsBlockEnd[0m In "UserDefinedEnum" from "GlobalScope" line 19":
+		<RBRACE> <SEMI_COLON> <NEWLINE>
+[36mcheck_utype_declaration_1.c[0m - [32mIsEmptyLine[0m In "GlobalScope" from "None" line 20":
+		<NEWLINE>
+[36mcheck_utype_declaration_1.c[0m - [32mIsFuncDeclaration[0m In "GlobalScope" from "None" line 21":
+		<ENUM> <SPACE> <IDENTIFIER=e_endian> <TAB> <IDENTIFIER=which_endian> <LPARENTHESIS> <VOID> <RPARENTHESIS> <NEWLINE>
+[36mcheck_utype_declaration_1.c[0m - [32mIsBlockStart[0m In "Function" from "GlobalScope" line 22":
+		<LBRACE> <NEWLINE>
+[36mcheck_utype_declaration_1.c[0m - [32mIsUserDefinedType[0m In "Function" from "GlobalScope" line 23":
+		<TAB> <UNION> <NEWLINE>
+[36mcheck_utype_declaration_1.c[0m - [32mIsBlockStart[0m In "UserDefinedType" from "Function" line 24":
+		<TAB> <LBRACE> <NEWLINE>
+[36mcheck_utype_declaration_1.c[0m - [32mIsVarDeclaration[0m In "UserDefinedType" from "Function" line 25":
+		<TAB> <TAB> <UNSIGNED> <SPACE> <CHAR> <TAB> <IDENTIFIER=var2> <LBRACKET> <CONSTANT=2> <RBRACKET> <SEMI_COLON> <NEWLINE>
+[36mcheck_utype_declaration_1.c[0m - [32mIsVarDeclaration[0m In "UserDefinedType" from "Function" line 26":
+		<TAB> <TAB> <UNSIGNED> <SPACE> <SHORT> <TAB> <IDENTIFIER=var1> <SEMI_COLON> <NEWLINE>
+[36mcheck_utype_declaration_1.c[0m - [32mIsBlockEnd[0m In "UserDefinedType" from "Function" line 27":
+		<TAB> <RBRACE> <TAB> <IDENTIFIER=u_endian> <SEMI_COLON> 
+[36mcheck_utype_declaration_1.c[0m - [32mIsComment[0m In "Function" from "GlobalScope" line 27":
+		<COMMENT=// This should be the correct indentation> <NEWLINE>
+[36mcheck_utype_declaration_1.c[0m - [32mIsComment[0m In "Function" from "GlobalScope" line 28":
+		<COMMENT=//	}					u_endian; > <NEWLINE>
+[36mcheck_utype_declaration_1.c[0m - [32mIsAssignation[0m In "Function" from "GlobalScope" line 29":
+		<TAB> <IDENTIFIER=u_endian> <DOT> <IDENTIFIER=var1> <SPACE> <ASSIGN> <SPACE> <CONSTANT=1> <SEMI_COLON> <NEWLINE>
+[36mcheck_utype_declaration_1.c[0m - [32mIsControlStatement[0m In "Function" from "GlobalScope" line 30":
+		<TAB> <IF> <SPACE> <LPARENTHESIS> <IDENTIFIER=u_endian> <DOT> <IDENTIFIER=var1> <SPACE> <EQUALS> <SPACE> <IDENTIFIER=u_endian> <DOT> <IDENTIFIER=var2> <LBRACKET> <CONSTANT=0> <RBRACKET> <RPARENTHESIS> <NEWLINE>
+[36mcheck_utype_declaration_1.c[0m - [32mIsExpressionStatement[0m In "ControlStructure" from "Function" line 31":
+		<TAB> <TAB> <RETURN> <SPACE> <LPARENTHESIS> <IDENTIFIER=LITTLE> <RPARENTHESIS> <SEMI_COLON> <NEWLINE>
+[36mcheck_utype_declaration_1.c[0m - [32mIsControlStatement[0m In "Function" from "GlobalScope" line 32":
+		<TAB> <ELSE> <NEWLINE>
+[36mcheck_utype_declaration_1.c[0m - [32mIsExpressionStatement[0m In "ControlStructure" from "Function" line 33":
+		<TAB> <TAB> <RETURN> <SPACE> <LPARENTHESIS> <IDENTIFIER=BIG> <RPARENTHESIS> <SEMI_COLON> <NEWLINE>
+[36mcheck_utype_declaration_1.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 34":
+		<RBRACE> <NEWLINE>
+check_utype_declaration_1.c: Error!
+Error: FORBIDDEN_STRUCT     (line:   1, col:   1):	Struct declaration are not allowed in .c files
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: FORBIDDEN_STRUCT     (line:   8, col:   5):	Struct declaration are not allowed in .c files
+Error: TYPE_NOT_GLOBAL      (line:   8, col:   5):	Enums, structs and unions need to be defined only in global scope
+Error: TYPE_NOT_GLOBAL      (line:  23, col:   5):	Enums, structs and unions need to be defined only in global scope
+Error: WRONG_SCOPE_COMMENT  (line:  27, col:  18):	Comment is invalid in this scope
+Error: WRONG_SCOPE_COMMENT  (line:  27, col:  18):	Comment is invalid in this scope
+Error: WRONG_SCOPE_COMMENT  (line:  28, col:   1):	Comment is invalid in this scope

--- a/tests/rules/samples/check_utype_declaration_1.out
+++ b/tests/rules/samples/check_utype_declaration_1.out
@@ -73,6 +73,8 @@ Error: FORBIDDEN_STRUCT     (line:   1, col:   1):	Struct declaration are not al
 Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
 Error: FORBIDDEN_STRUCT     (line:   8, col:   5):	Struct declaration are not allowed in .c files
 Error: TYPE_NOT_GLOBAL      (line:   8, col:   5):	Enums, structs and unions need to be defined only in global scope
+Error: FORBIDDEN_ENUM       (line:  15, col:   1):	Enum declaration are not allowed in .c files
+Error: FORBIDDEN_UNION      (line:  23, col:   5):	Union declaration are not allowed in .c files
 Error: TYPE_NOT_GLOBAL      (line:  23, col:   5):	Enums, structs and unions need to be defined only in global scope
 Error: WRONG_SCOPE_COMMENT  (line:  27, col:  18):	Comment is invalid in this scope
 Error: WRONG_SCOPE_COMMENT  (line:  27, col:  18):	Comment is invalid in this scope

--- a/tests/rules/samples/check_utype_declaration_2.h
+++ b/tests/rules/samples/check_utype_declaration_2.h
@@ -1,0 +1,12 @@
+struct
+{
+	int	a;
+};
+
+struct
+{
+	struct
+	{
+		int	b;
+	}	s_a;
+};

--- a/tests/rules/samples/check_utype_declaration_2.out
+++ b/tests/rules/samples/check_utype_declaration_2.out
@@ -1,0 +1,26 @@
+[36mcheck_utype_declaration_2.h[0m - [32mIsUserDefinedType[0m In "GlobalScope" from "None" line 1":
+		<STRUCT> <NEWLINE>
+[36mcheck_utype_declaration_2.h[0m - [32mIsBlockStart[0m In "UserDefinedType" from "GlobalScope" line 2":
+		<LBRACE> <NEWLINE>
+[36mcheck_utype_declaration_2.h[0m - [32mIsVarDeclaration[0m In "UserDefinedType" from "GlobalScope" line 3":
+		<TAB> <INT> <TAB> <IDENTIFIER=a> <SEMI_COLON> <NEWLINE>
+[36mcheck_utype_declaration_2.h[0m - [32mIsBlockEnd[0m In "UserDefinedType" from "GlobalScope" line 4":
+		<RBRACE> <SEMI_COLON> <NEWLINE>
+[36mcheck_utype_declaration_2.h[0m - [32mIsEmptyLine[0m In "GlobalScope" from "None" line 5":
+		<NEWLINE>
+[36mcheck_utype_declaration_2.h[0m - [32mIsUserDefinedType[0m In "GlobalScope" from "None" line 6":
+		<STRUCT> <NEWLINE>
+[36mcheck_utype_declaration_2.h[0m - [32mIsBlockStart[0m In "UserDefinedType" from "GlobalScope" line 7":
+		<LBRACE> <NEWLINE>
+[36mcheck_utype_declaration_2.h[0m - [32mIsUserDefinedType[0m In "UserDefinedType" from "GlobalScope" line 8":
+		<TAB> <STRUCT> <NEWLINE>
+[36mcheck_utype_declaration_2.h[0m - [32mIsBlockStart[0m In "UserDefinedType" from "UserDefinedType" line 9":
+		<TAB> <LBRACE> <NEWLINE>
+[36mcheck_utype_declaration_2.h[0m - [32mIsVarDeclaration[0m In "UserDefinedType" from "UserDefinedType" line 10":
+		<TAB> <TAB> <INT> <TAB> <IDENTIFIER=b> <SEMI_COLON> <NEWLINE>
+[36mcheck_utype_declaration_2.h[0m - [32mIsBlockEnd[0m In "UserDefinedType" from "UserDefinedType" line 11":
+		<TAB> <RBRACE> <TAB> <IDENTIFIER=s_a> <SEMI_COLON> <NEWLINE>
+[36mcheck_utype_declaration_2.h[0m - [32mIsBlockEnd[0m In "UserDefinedType" from "GlobalScope" line 12":
+		<RBRACE> <SEMI_COLON> <NEWLINE>
+check_utype_declaration_2.h: Error!
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header

--- a/tests/rules/samples/ko_struct_indent.out
+++ b/tests/rules/samples/ko_struct_indent.out
@@ -36,6 +36,7 @@ Error: MISALIGNED_VAR_DECL  (line:   2, col:  29):	Misaligned variable declarati
 Notice: GLOBAL_VAR_DETECTED  (line:   3, col:   1):	Global variable present in file. Make sure it is a reasonable choice.
 Error: MISALIGNED_VAR_DECL  (line:   3, col:  29):	Misaligned variable declaration
 Error: MULT_DECL_LINE       (line:   3, col:  34):	Multiple declarations on a single line
+Error: FORBIDDEN_STRUCT     (line:   5, col:   9):	Struct declaration are not allowed in .c files
 Error: BRACE_NEWLINE        (line:   5, col:  23):	Expected newline before brace
 Error: MISALIGNED_VAR_DECL  (line:   7, col:  29):	Misaligned variable declaration
 Error: MISALIGNED_VAR_DECL  (line:   8, col:   1):	Misaligned variable declaration

--- a/tests/rules/samples/ko_struct_indent.out
+++ b/tests/rules/samples/ko_struct_indent.out
@@ -29,6 +29,7 @@
 [36mko_struct_indent.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 15":
 		<RBRACE> <NEWLINE>
 ko_struct_indent.c: Error!
+Error: FORBIDDEN_TYPEDEF    (line:   1, col:   1):	Typedef declaration are not allowed in .c files
 Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
 Notice: GLOBAL_VAR_DETECTED  (line:   2, col:   1):	Global variable present in file. Make sure it is a reasonable choice.
 Error: GLOBAL_VAR_NAMING    (line:   2, col:  29):	Global variable must start with g_
@@ -36,7 +37,7 @@ Error: MISALIGNED_VAR_DECL  (line:   2, col:  29):	Misaligned variable declarati
 Notice: GLOBAL_VAR_DETECTED  (line:   3, col:   1):	Global variable present in file. Make sure it is a reasonable choice.
 Error: MISALIGNED_VAR_DECL  (line:   3, col:  29):	Misaligned variable declaration
 Error: MULT_DECL_LINE       (line:   3, col:  34):	Multiple declarations on a single line
-Error: FORBIDDEN_STRUCT     (line:   5, col:   9):	Struct declaration are not allowed in .c files
+Error: FORBIDDEN_TYPEDEF    (line:   5, col:   1):	Typedef declaration are not allowed in .c files
 Error: BRACE_NEWLINE        (line:   5, col:  23):	Expected newline before brace
 Error: MISALIGNED_VAR_DECL  (line:   7, col:  29):	Misaligned variable declaration
 Error: MISALIGNED_VAR_DECL  (line:   8, col:   1):	Misaligned variable declaration

--- a/tests/rules/samples/ko_struct_name.out
+++ b/tests/rules/samples/ko_struct_name.out
@@ -29,13 +29,14 @@
 [36mko_struct_name.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 15":
 		<RBRACE> <NEWLINE>
 ko_struct_name.c: Error!
+Error: FORBIDDEN_TYPEDEF    (line:   1, col:   1):	Typedef declaration are not allowed in .c files
 Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
 Error: USER_DEFINED_TYPEDEF (line:   1, col:  25):	User defined typedef must start with t_
 Notice: GLOBAL_VAR_DETECTED  (line:   2, col:   1):	Global variable present in file. Make sure it is a reasonable choice.
 Error: GLOBAL_VAR_NAMING    (line:   2, col:  25):	Global variable must start with g_
 Notice: GLOBAL_VAR_DETECTED  (line:   3, col:   1):	Global variable present in file. Make sure it is a reasonable choice.
 Error: GLOBAL_VAR_NAMING    (line:   3, col:  25):	Global variable must start with g_
-Error: FORBIDDEN_STRUCT     (line:   5, col:   9):	Struct declaration are not allowed in .c files
+Error: FORBIDDEN_TYPEDEF    (line:   5, col:   1):	Typedef declaration are not allowed in .c files
 Error: BRACE_NEWLINE        (line:   5, col:  21):	Expected newline before brace
 Error: USER_DEFINED_TYPEDEF (line:   8, col:  25):	User defined typedef must start with t_
 Error: USER_DEFINED_TYPEDEF (line:  10, col:   5):	User defined typedef must start with t_

--- a/tests/rules/samples/ko_struct_name.out
+++ b/tests/rules/samples/ko_struct_name.out
@@ -35,6 +35,7 @@ Notice: GLOBAL_VAR_DETECTED  (line:   2, col:   1):	Global variable present in f
 Error: GLOBAL_VAR_NAMING    (line:   2, col:  25):	Global variable must start with g_
 Notice: GLOBAL_VAR_DETECTED  (line:   3, col:   1):	Global variable present in file. Make sure it is a reasonable choice.
 Error: GLOBAL_VAR_NAMING    (line:   3, col:  25):	Global variable must start with g_
+Error: FORBIDDEN_STRUCT     (line:   5, col:   9):	Struct declaration are not allowed in .c files
 Error: BRACE_NEWLINE        (line:   5, col:  21):	Expected newline before brace
 Error: USER_DEFINED_TYPEDEF (line:   8, col:  25):	User defined typedef must start with t_
 Error: USER_DEFINED_TYPEDEF (line:  10, col:   5):	User defined typedef must start with t_

--- a/tests/rules/samples/long_test.out
+++ b/tests/rules/samples/long_test.out
@@ -190,6 +190,7 @@ Error: GLOBAL_VAR_NAMING    (line:  38, col:   8):	Global variable must start wi
 Error: NO_SPC_AFR_PAR       (line:  38, col:  17):	Extra space after parenthesis (brace/bracket)
 Error: SPACE_REPLACE_TAB    (line:  39, col:   4):	Found space when expecting tab
 Error: EXP_PARENTHESIS      (line:  39, col:  10):	Expected parenthesis
+Error: FORBIDDEN_ENUM       (line:  40, col:   1):	Enum declaration are not allowed in .c files
 Error: ENUM_TYPE_NAMING     (line:  40, col:   6):	Enum name must start with e_
 Error: BRACE_NEWLINE        (line:  40, col:  10):	Expected newline before brace
 Error: MISALIGNED_FUNC_DECL (line:  46, col:  21):	Misaligned function declaration

--- a/tests/rules/samples/ok_enum.out
+++ b/tests/rules/samples/ok_enum.out
@@ -11,4 +11,5 @@
 [36mok_enum.c[0m - [32mIsBlockEnd[0m In "UserDefinedEnum" from "GlobalScope" line 6":
 		<RBRACE> <TAB> <IDENTIFIER=t_toto> <SEMI_COLON> <NEWLINE>
 ok_enum.c: Error!
+Error: FORBIDDEN_TYPEDEF    (line:   1, col:   1):	Typedef declaration are not allowed in .c files
 Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header

--- a/tests/rules/samples/ok_func_name.out
+++ b/tests/rules/samples/ok_func_name.out
@@ -42,7 +42,9 @@
 		<RBRACE> <NEWLINE>
 ok_func_name.c: Error!
 Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: FORBIDDEN_TYPEDEF    (line:   8, col:   1):	Typedef declaration are not allowed in .c files
 Error: FORBIDDEN_CHAR_NAME  (line:   8, col:  25):	user defined identifiers should contain only lowercase characters, digits or '_'
+Error: FORBIDDEN_STRUCT     (line:   9, col:   1):	Struct declaration are not allowed in .c files
 Error: FORBIDDEN_CHAR_NAME  (line:   9, col:  25):	user defined identifiers should contain only lowercase characters, digits or '_'
 Notice: GLOBAL_VAR_DETECTED  (line:  11, col:   1):	Global variable present in file. Make sure it is a reasonable choice.
 Error: FORBIDDEN_CHAR_NAME  (line:  11, col:  25):	user defined identifiers should contain only lowercase characters, digits or '_'

--- a/tests/rules/samples/ok_func_ptr.out
+++ b/tests/rules/samples/ok_func_ptr.out
@@ -25,3 +25,5 @@
 ok_func_ptr.c: Error!
 Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
 Notice: GLOBAL_VAR_DETECTED  (line:   2, col:   1):	Global variable present in file. Make sure it is a reasonable choice.
+Error: FORBIDDEN_TYPEDEF    (line:   5, col:   1):	Typedef declaration are not allowed in .c files
+Error: FORBIDDEN_TYPEDEF    (line:   6, col:   1):	Typedef declaration are not allowed in .c files

--- a/tests/rules/samples/ok_struct_name.out
+++ b/tests/rules/samples/ok_struct_name.out
@@ -35,8 +35,8 @@
 [36mok_struct_name.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 18":
 		<RBRACE> <NEWLINE>
 ok_struct_name.c: Error!
+Error: FORBIDDEN_TYPEDEF    (line:   1, col:   1):	Typedef declaration are not allowed in .c files
 Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
-Error: FORBIDDEN_STRUCT     (line:   1, col:   9):	Struct declaration are not allowed in .c files
 Error: FORBIDDEN_STRUCT     (line:   5, col:   1):	Struct declaration are not allowed in .c files
 Notice: GLOBAL_VAR_DETECTED  (line:  11, col:   1):	Global variable present in file. Make sure it is a reasonable choice.
 Notice: GLOBAL_VAR_DETECTED  (line:  12, col:   1):	Global variable present in file. Make sure it is a reasonable choice.

--- a/tests/rules/samples/ok_struct_name.out
+++ b/tests/rules/samples/ok_struct_name.out
@@ -36,5 +36,7 @@
 		<RBRACE> <NEWLINE>
 ok_struct_name.c: Error!
 Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: FORBIDDEN_STRUCT     (line:   1, col:   9):	Struct declaration are not allowed in .c files
+Error: FORBIDDEN_STRUCT     (line:   5, col:   1):	Struct declaration are not allowed in .c files
 Notice: GLOBAL_VAR_DETECTED  (line:  11, col:   1):	Global variable present in file. Make sure it is a reasonable choice.
 Notice: GLOBAL_VAR_DETECTED  (line:  12, col:   1):	Global variable present in file. Make sure it is a reasonable choice.

--- a/tests/rules/samples/ok_typedef.out
+++ b/tests/rules/samples/ok_typedef.out
@@ -33,6 +33,7 @@
 [36mok_typedef.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 17":
 		<RBRACE> <NEWLINE>
 ok_typedef.c: Error!
+Error: FORBIDDEN_TYPEDEF    (line:   1, col:   1):	Typedef declaration are not allowed in .c files
 Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
-Error: FORBIDDEN_STRUCT     (line:   1, col:   9):	Struct declaration are not allowed in .c files
+Error: FORBIDDEN_TYPEDEF    (line:   7, col:   1):	Typedef declaration are not allowed in .c files
 Error: FORBIDDEN_STRUCT     (line:   9, col:   1):	Struct declaration are not allowed in .c files

--- a/tests/rules/samples/ok_typedef.out
+++ b/tests/rules/samples/ok_typedef.out
@@ -34,3 +34,5 @@
 		<RBRACE> <NEWLINE>
 ok_typedef.c: Error!
 Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: FORBIDDEN_STRUCT     (line:   1, col:   9):	Struct declaration are not allowed in .c files
+Error: FORBIDDEN_STRUCT     (line:   9, col:   1):	Struct declaration are not allowed in .c files

--- a/tests/rules/samples/test_comments.out
+++ b/tests/rules/samples/test_comments.out
@@ -47,6 +47,7 @@
 [36mtest_comments.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 21":
 		<RBRACE> <NEWLINE>
 test_comments.c: Error!
+Error: FORBIDDEN_STRUCT     (line:   1, col:   1):	Struct declaration are not allowed in .c files
 Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
 Error: BRACE_NEWLINE        (line:   1, col:   8):	Expected newline before brace
 Error: COMMENT_ON_INSTR     (line:   6, col:   9):	Comment must be on its own line or at end of a line

--- a/tests/rules/samples/test_comments.out
+++ b/tests/rules/samples/test_comments.out
@@ -50,9 +50,11 @@ test_comments.c: Error!
 Error: FORBIDDEN_STRUCT     (line:   1, col:   1):	Struct declaration are not allowed in .c files
 Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
 Error: BRACE_NEWLINE        (line:   1, col:   8):	Expected newline before brace
+Error: FORBIDDEN_TYPEDEF    (line:   6, col:   1):	Typedef declaration are not allowed in .c files
 Error: COMMENT_ON_INSTR     (line:   6, col:   9):	Comment must be on its own line or at end of a line
 Error: SPACE_REPLACE_TAB    (line:   6, col:  25):	Found space when expecting tab
 Error: USER_DEFINED_TYPEDEF (line:   6, col:  26):	User defined typedef must start with t_
+Error: FORBIDDEN_ENUM       (line:   8, col:   1):	Enum declaration are not allowed in .c files
 Error: ENUM_TYPE_NAMING     (line:   8, col:   6):	Enum name must start with e_
 Error: BRACE_NEWLINE        (line:   8, col:  11):	Expected newline before brace
 Error: SPACE_EMPTY_LINE     (line:   9, col:   5):	Space on empty line

--- a/tests/rules/samples/test_file_1019.out
+++ b/tests/rules/samples/test_file_1019.out
@@ -163,6 +163,7 @@
 test_file_1019.c: Error!
 Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
 Error: RETURN_PARENTHESIS   (line:   8, col:  12):	Return value must be in parenthesis
+Error: FORBIDDEN_STRUCT     (line:  11, col:   1):	Struct declaration are not allowed in .c files
 Error: FORBIDDEN_CHAR_NAME  (line:  28, col:   9):	user defined identifiers should contain only lowercase characters, digits or '_'
 Error: COMMENT_ON_INSTR     (line:  35, col:   6):	Comment must be on its own line or at end of a line
 Error: COMMENT_ON_INSTR     (line:  41, col:  10):	Comment must be on its own line or at end of a line

--- a/tests/rules/samples/test_file_1019_1.out
+++ b/tests/rules/samples/test_file_1019_1.out
@@ -31,4 +31,5 @@
 test_file_1019_1.c: Error!
 Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
 Error: PREPROC_BAD_IFNDEF   (line:   1, col:   1):	Ifndef preprocessor statement without endif
+Error: FORBIDDEN_TYPEDEF    (line:   4, col:   1):	Typedef declaration are not allowed in .c files
 Error: FORBIDDEN_STRUCT     (line:   5, col:   1):	Struct declaration are not allowed in .c files

--- a/tests/rules/samples/test_file_1019_1.out
+++ b/tests/rules/samples/test_file_1019_1.out
@@ -31,3 +31,4 @@
 test_file_1019_1.c: Error!
 Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
 Error: PREPROC_BAD_IFNDEF   (line:   1, col:   1):	Ifndef preprocessor statement without endif
+Error: FORBIDDEN_STRUCT     (line:   5, col:   1):	Struct declaration are not allowed in .c files

--- a/tests/rules/samples/test_file_1022.out
+++ b/tests/rules/samples/test_file_1022.out
@@ -27,5 +27,7 @@
 [36mtest_file_1022.c[0m - [32mIsBlockEnd[0m In "UserDefinedType" from "GlobalScope" line 14":
 		<RBRACE> <SEMI_COLON> 
 test_file_1022.c: Error!
+Error: FORBIDDEN_STRUCT     (line:   1, col:   1):	Struct declaration are not allowed in .c files
 Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
 Error: SPACE_REPLACE_TAB    (line:   9, col:   4):	Found space when expecting tab
+Error: FORBIDDEN_STRUCT     (line:  11, col:   1):	Struct declaration are not allowed in .c files

--- a/tests/rules/samples/test_file_1116_1.out
+++ b/tests/rules/samples/test_file_1116_1.out
@@ -13,4 +13,5 @@
 [36mtest_file_1116_1.c[0m - [32mIsBlockEnd[0m In "UserDefinedEnum" from "GlobalScope" line 7":
 		<RBRACE> <SEMI_COLON> 
 test_file_1116_1.c: Error!
+Error: FORBIDDEN_ENUM       (line:   1, col:   1):	Enum declaration are not allowed in .c files
 Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header

--- a/tests/rules/samples/test_file_1116_2.out
+++ b/tests/rules/samples/test_file_1116_2.out
@@ -19,4 +19,5 @@
 		<IDENTIFIER=fourth_enum_with_value_based_on_other_enums> <SPACE> <ASSIGN> <SPACE> <LPARENTHESIS> <IDENTIFIER=first_enum_with_value_zero> <NEWLINE>
 		<TAB> <TAB> <BWISE_OR> <SPACE> <IDENTIFIER=second_enum> <SPACE> <BWISE_OR> <SPACE> <IDENTIFIER=third_enum> <RPARENTHESIS> <SEMI_COLON> <NEWLINE>
 test_file_1116_2.c: Error!
+Error: FORBIDDEN_ENUM       (line:   1, col:   1):	Enum declaration are not allowed in .c files
 Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header

--- a/tests/rules/samples/test_file_210218_3.out
+++ b/tests/rules/samples/test_file_210218_3.out
@@ -10,5 +10,8 @@
 		<TYPEDEF> <SPACE> <VOID> <TAB> <LPARENTHESIS> <MULT> <IDENTIFIER=t_func_definiton> <RPARENTHESIS> <LPARENTHESIS> <IDENTIFIER=toto> <SPACE> <IDENTIFIER=arg> <RPARENTHESIS> <SEMI_COLON> 
 test_file_210218_3.c: Error!
 Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: FORBIDDEN_TYPEDEF    (line:   2, col:   1):	Typedef declaration are not allowed in .c files
 Error: NL_AFTER_PREPROC     (line:   2, col:   1):	Preprocessor statement must be followed by a newline
+Error: FORBIDDEN_TYPEDEF    (line:   3, col:   1):	Typedef declaration are not allowed in .c files
 Error: FORBIDDEN_CHAR_NAME  (line:   3, col:  24):	user defined identifiers should contain only lowercase characters, digits or '_'
+Error: FORBIDDEN_TYPEDEF    (line:   5, col:   1):	Typedef declaration are not allowed in .c files

--- a/tests/rules/samples/test_file_210304.out
+++ b/tests/rules/samples/test_file_210304.out
@@ -56,7 +56,7 @@
 [36mtest_file_210304.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 31":
 		<RBRACE> <NEWLINE>
 test_file_210304.c: Error!
+Error: FORBIDDEN_TYPEDEF    (line:   1, col:   1):	Typedef declaration are not allowed in .c files
 Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
-Error: FORBIDDEN_STRUCT     (line:   1, col:   9):	Struct declaration are not allowed in .c files
-Error: FORBIDDEN_STRUCT     (line:   6, col:   9):	Struct declaration are not allowed in .c files
-Error: FORBIDDEN_STRUCT     (line:  14, col:   9):	Struct declaration are not allowed in .c files
+Error: FORBIDDEN_TYPEDEF    (line:   6, col:   1):	Typedef declaration are not allowed in .c files
+Error: FORBIDDEN_TYPEDEF    (line:  14, col:   1):	Typedef declaration are not allowed in .c files

--- a/tests/rules/samples/test_file_210304.out
+++ b/tests/rules/samples/test_file_210304.out
@@ -57,3 +57,6 @@
 		<RBRACE> <NEWLINE>
 test_file_210304.c: Error!
 Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: FORBIDDEN_STRUCT     (line:   1, col:   9):	Struct declaration are not allowed in .c files
+Error: FORBIDDEN_STRUCT     (line:   6, col:   9):	Struct declaration are not allowed in .c files
+Error: FORBIDDEN_STRUCT     (line:  14, col:   9):	Struct declaration are not allowed in .c files

--- a/tests/rules/samples/testfile_210104_2.out
+++ b/tests/rules/samples/testfile_210104_2.out
@@ -51,3 +51,4 @@
 testfile_210104_2.c: Error!
 Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
 Error: WRONG_SCOPE_COMMENT  (line:   5, col:   5):	Comment is invalid in this scope
+Error: FORBIDDEN_TYPEDEF    (line:  18, col:   1):	Typedef declaration are not allowed in .c files


### PR DESCRIPTION
Fixes #437, #435 and #347.

~~I did to show an error when a struct is in a C file, but what about `enum`, `union` and `typedef`, must they also be fobidden?~~
- [x] Add to report error when struct is in C file
- [x] Add to report error when union is in C file
- [x] Add to report error when enum is in C file
- [x] Add to report error when typedef is in C file