### PR TITLE
add "File" and "Errors" classes

### DIFF
--- a/norminette/__main__.py
+++ b/norminette/__main__.py
@@ -1,31 +1,17 @@
 import glob
-import os
 import sys
+import pathlib
 from importlib.metadata import version
 
 import argparse
+from norminette.file import File
 from norminette.lexer import Lexer, TokenError
 from norminette.exceptions import CParsingError
 from norminette.registry import Registry
 from norminette.context import Context
 from norminette.tools.colors import colors
 
-from pathlib import Path
-
-import _thread
-from threading import Event
-import time
 import subprocess
-
-
-has_err = False
-
-
-def timeout(e, timeval=5):
-    time.sleep(timeval)
-    if e.is_set():
-        return
-    _thread.interrupt_main()
 
 
 def main():
@@ -33,8 +19,6 @@ def main():
     parser.add_argument(
         "file",
         help="File(s) or folder(s) you wanna run the parser on. If no file provided, runs on current folder.",
-        default=[],
-        action="append",
         nargs="*",
     )
     parser.add_argument(
@@ -80,36 +64,36 @@ def main():
     parser.add_argument("-R", nargs=1, help="compatibility for norminette 2")
     args = parser.parse_args()
     registry = Registry()
-    targets = []
-    has_err = None
-    content = None
 
+    files = []
     debug = args.debug
-    if args.cfile is not None or args.hfile is not None:
-        if args.filename:
-            targets = [args.filename]
-        else:
-            targets = ["file.c"] if args.cfile else ["file.h"]
-        content = args.cfile if args.cfile else args.hfile
+    if args.cfile or args.hfile:
+        file_name = args.filename or ("file.c" if args.cfile else "file.h")
+        file_data = args.cfile if args.cfile else args.hfile
+        file = File(file_name, file_data)
+        files.append(file)
     else:
-        args.file = args.file[0]
-        if args.file == [[]] or args.file == []:
-            targets = glob.glob("**/*.[ch]", recursive=True)
-        else:
-            for arg in args.file:
-                if os.path.exists(arg) is False:
-                    print(f"'{arg}' no such file or directory")
-                elif os.path.isdir(arg):
-                    if arg[-1] != "/":
-                        arg = arg + "/"
-                    targets.extend(glob.glob(arg + "**/*.[ch]", recursive=True))
-                elif os.path.isfile(arg):
-                    targets.append(arg)
+        stack = []
+        stack += args.file if args.file else glob.glob("**/*.[ch]", recursive=True)
+        for item in stack:
+            path = pathlib.Path(item)
+            if not path.exists():
+                print(f"Error: '{path!s}' no such file or directory")
+                sys.exit(1)
+            if path.is_file():
+                if path.suffix not in (".c", ".h"):
+                    print(f"Error: {path.name!r} is not valid C or C header file")
+                else:
+                    file = File(item)
+                    files.append(file)
+            if path.is_dir():
+                stack += glob.glob(str(path) + "/**/*.[ch]", recursive=True)
+        del stack
 
     if args.use_gitignore:
         tmp_targets = []
-        for target in targets:
-            command = ["git", "check-ignore", "-q", target]
+        for target in files:
+            command = ["git", "check-ignore", "-q", target.path]
             exit_code = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE).returncode
             """
             see: $ man git-check-ignore
@@ -123,51 +107,21 @@ def main():
             elif exit_code == 1:
                 tmp_targets.append(target)
             elif exit_code == 128:
-                print(f'Error: something wrong with --use-gitignore option {target}')
+                print(f'Error: something wrong with --use-gitignore option {target.path!r}')
                 sys.exit(0)
-        targets = tmp_targets
-    event = []
-    for target in filter(os.path.isfile, targets):
-        if target[-2:] not in [".c", ".h"]:
-            print(f"Error: {target} is not valid C or C header file")
-        else:
-            try:
-                event.append(Event())
-                if content is None:
-                    with open(target) as f:
-                        try:
-                            source = f.read()
-                        except Exception as e:
-                            print("Error: File could not be read: ", e)
-                            sys.exit(0)
-                else:
-                    source = content
-                try:
-                    lexer = Lexer(source)
-                    tokens = lexer.get_tokens()
-                except KeyError as e:
-                    print("Error while parsing file:", e)
-                    sys.exit(0)
-                if args.only_filename is True:
-                    # target = target.split("/")[-1]
-                    target = Path(target).name
-                context = Context(target, tokens, debug, args.R)
-                registry.run(context, source)
-                event[-1].set()
-                if context.errors:
-                    has_err = True
-            except TokenError as e:
-                has_err = True
-                print(target + f": Error!\n\t{colors(e.msg, 'red')}")
-                event[-1].set()
-            except CParsingError as e:
-                has_err = True
-                print(target + f": Error!\n\t{colors(e.msg, 'red')}")
-                event[-1].set()
-            except KeyboardInterrupt:
-                event[-1].set()
-                sys.exit(1)
-    sys.exit(1 if has_err else 0)
+        files = tmp_targets
+    for file in files:
+        try:
+            lexer = Lexer(file)
+            tokens = lexer.get_tokens()
+            context = Context(file, tokens, debug, args.R)
+            registry.run(context)
+        except (TokenError, CParsingError) as e:
+            print(file.path + f": Error!\n\t{colors(e.msg, 'red')}")
+            sys.exit(1)
+        except KeyboardInterrupt:
+            sys.exit(1)
+    sys.exit(1 if len(file.errors) else 0)
 
 
 if __name__ == "__main__":

--- a/norminette/context.py
+++ b/norminette/context.py
@@ -182,21 +182,19 @@ class PreProcessors:
 
 
 class Context:
-    def __init__(self, filename, tokens, debug=0, added_value=[]):
+    def __init__(self, file, tokens, debug=0, added_value=[]):
         # Header relative informations
         self.header_started = False
         self.header_parsed = False
         self.header = ""
         # File relative informations
-        self.filename = filename
-        self.filetype = filename.split(".")[-1]  # ?
+        self.file = file
         self.tokens = tokens
         self.debug = int(debug)
 
         # Rule relative informations
         self.history = []
-        self.errors = []
-        self.warnings = []
+        self.errors = file.errors
         self.tkn_scope = len(tokens)
 
         # Scope informations
@@ -250,7 +248,7 @@ class Context:
         self.errors.append(NormError(errno, pos[0], pos[1]))
 
     def new_warning(self, errno, tkn):
-        self.warnings.append(NormWarning(errno, tkn.pos[0], tkn.pos[1]))
+        self.errors.append(NormWarning(errno, tkn.pos[0], tkn.pos[1]))
 
     def get_parent_rule(self):
         if len(self.history) == 0:
@@ -288,7 +286,7 @@ class Context:
         if self.debug < 2:
             return
         print(
-            f"{colors(self.filename, 'cyan')} - {colors(rule, 'green')} \
+            f"{colors(self.file.basename, 'cyan')} - {colors(rule, 'green')} \
 In \"{self.scope.name}\" from \
 \"{self.scope.parent.name if self.scope.parent is not  None else None}\" line {self.tokens[0].pos[0]}\":"
         )

--- a/norminette/file.py
+++ b/norminette/file.py
@@ -1,0 +1,57 @@
+import os
+from functools import cmp_to_key
+from typing import Optional, Union, Literal
+
+from norminette.norm_error import NormError, NormWarning
+
+
+def sort_errs(a, b):
+    if a.col == b.col and a.line == b.line:
+        return 1 if a.errno > b.errno else -1
+    return a.col - b.col if a.line == b.line else a.line - b.line
+
+
+class Errors:
+    __slots__ = "_inner"
+
+    def __init__(self) -> None:
+        self._inner = []
+
+    def __len__(self) -> int:
+        return len(self._inner)
+
+    def __iter__(self):
+        self._inner.sort(key=cmp_to_key(sort_errs))
+        return iter(self._inner)
+
+    @property
+    def status(self) -> Literal["OK", "Error"]:
+        if not self:
+            return "OK"
+        if all(isinstance(it, NormWarning) for it in self):
+            return "OK"
+        return "Error"
+
+    def append(self, value: Union[NormError, NormWarning]) -> None:
+        assert isinstance(value, (NormError, NormWarning))
+        self._inner.append(value)
+
+
+class File:
+    def __init__(self, path: str, source: Optional[str] = None) -> None:
+        self.path = path
+        self._source = source
+
+        self.errors = Errors()
+        self.basename = os.path.basename(path)
+        self.name, self.type = os.path.splitext(self.basename)
+
+    @property
+    def source(self) -> str:
+        if not self._source:
+            with open(self.path) as file:
+                self._source = file.read()
+        return self._source
+
+    def __repr__(self) -> str:
+        return f"<File {self.path!r}>"

--- a/norminette/lexer/lexer.py
+++ b/norminette/lexer/lexer.py
@@ -4,6 +4,7 @@ from norminette.lexer.dictionary import brackets
 from norminette.lexer.dictionary import keywords
 from norminette.lexer.dictionary import operators
 from norminette.lexer.tokens import Token
+from norminette.file import File
 
 
 def read_file(filename):
@@ -20,13 +21,14 @@ class TokenError(Exception):
 
 
 class Lexer:
-    def __init__(self, source_code, starting_line=1):
-        self.src = source_code
-        self.len = len(source_code)
+    def __init__(self, file: File):
+        self.file = file
+
+        self.src = file.source
+        self.len = len(file.source)
         self.__char = self.src[0] if self.src != "" else None
         self.__pos = int(0)
-        self.__line_pos = int(starting_line)
-        self.__line = int(starting_line)
+        self.__line_pos = self.__line = 1
         self.tokens = []
 
     def peek_sub_string(self, size):

--- a/norminette/lexer/lexer.py
+++ b/norminette/lexer/lexer.py
@@ -157,8 +157,7 @@ class Lexer:
             tkn_value += self.peek_char()
             if self.peek_char() == "\n":
                 self.pop_char()
-                self.tokens.append(Token("TKN_ERROR", pos))
-                return
+                raise TokenError(pos)
             if self.peek_char() == "'":
                 self.pop_char()
                 self.tokens.append(Token("CHAR_CONST", pos, tkn_value))

--- a/norminette/registry.py
+++ b/norminette/registry.py
@@ -1,17 +1,10 @@
 import collections
-from functools import cmp_to_key
 from operator import attrgetter
 
 from norminette.rules import Rules, Primary
 from norminette.exceptions import CParsingError
 
 rules = Rules()
-
-
-def sort_errs(a, b):
-    if a.col == b.col and a.line == b.line:
-        return 1 if a.errno > b.errno else -1
-    return a.col - b.col if a.line == b.line else a.line - b.line
 
 
 class Registry:
@@ -40,7 +33,7 @@ class Registry:
             context.tkn_scope = 0
         return ret, read
 
-    def run(self, context, source):
+    def run(self, context):
         """
         Main function for each file.
         Primary rules are determined by the prefix "Is" and
@@ -85,17 +78,6 @@ class Registry:
             print(context.debug)
             if context.debug > 0:
                 print("uncaught ->", unrecognized_tkns)
-        if context.errors == []:
-            print(context.filename + ": OK!")
-            for warning in sorted(context.warnings, key=cmp_to_key(sort_errs)):
-                print(warning)
-        else:
-            print(context.filename + ": Error!")
-            context.errors = sorted(
-                context.errors + context.warnings, key=cmp_to_key(sort_errs)
-            )
-            for err in context.errors:
-                print(err)
-            # context.warnings = sorted(context.warnings, key=cmp_to_key(sort_errs))
-            # for warn in context.warnings:
-            #     print (warn)
+        print(f"{context.file.basename}: {context.file.errors.status}!")
+        for error in context.file.errors:
+            print(error)

--- a/norminette/rules/check_in_header.py
+++ b/norminette/rules/check_in_header.py
@@ -42,7 +42,7 @@ class CheckInHeader(Rule, Check):
             - Comments
             - Function prototypes
         """
-        if context.filetype != "h":
+        if context.file.type != ".h":
             return False, 0
         sc = context.scope
         while sc.name != "GlobalScope":

--- a/norminette/rules/check_preprocessor_protection.py
+++ b/norminette/rules/check_preprocessor_protection.py
@@ -1,5 +1,4 @@
 import itertools
-from pathlib import Path
 
 from norminette.rules import Rule, Check
 

--- a/norminette/rules/check_preprocessor_protection.py
+++ b/norminette/rules/check_preprocessor_protection.py
@@ -19,7 +19,7 @@ class CheckPreprocessorProtection(Rule, Check):
         ```
         Any header instruction must be within the header protection
         """
-        if context.filetype != "h":
+        if context.file.type != ".h":
             return False, 0
         i = context.skip_ws(0)
         hash = context.peek_token(i)
@@ -32,7 +32,7 @@ class CheckPreprocessorProtection(Rule, Check):
         if not t or t.type != "IDENTIFIER" or t.value.upper() not in ("IFNDEF", "ENDIF"):
             return False, 0
         i += 1
-        guard = Path(context.filename).name.upper().replace(".", "_")
+        guard = context.file.basename.upper().replace(".", "_")
         if t.value.upper() == "ENDIF":
             if context.preproc.indent == 0 and not context.protected:
                 i = context.skip_ws(i, nl=True, comment=True)

--- a/norminette/rules/check_utype_declaration.py
+++ b/norminette/rules/check_utype_declaration.py
@@ -41,7 +41,7 @@ class CheckUtypeDeclaration(Rule, Check):
         if context.scope.name not in ("GlobalScope", "UserDefinedType"):
             context.new_error("TYPE_NOT_GLOBAL", token)
         if (
-            context.filetype == "c"
+            context.file.type == ".c"
             and token.type in ("STRUCT", "UNION", "ENUM", "TYPEDEF")
             and context.scope not in ("UserDefinedType", "UserDefinedEnum")
         ):

--- a/tests/lexer/brackets_tokens_test.py
+++ b/tests/lexer/brackets_tokens_test.py
@@ -1,27 +1,19 @@
-import unittest
+import pytest
 
-from norminette.lexer.lexer import Lexer
+from norminette.file import File
+from norminette.lexer import Lexer
 
-
-class BracketsTokensTest(unittest.TestCase):
-    def test_opening_bracket(self):
-        self.assertEqual(Lexer("{").get_next_token().type, "LBRACE")
-
-    def test_closing_bracket(self):
-        self.assertEqual(Lexer("}").get_next_token().type, "RBRACE")
-
-    def test_opening_parenthesis(self):
-        self.assertEqual(Lexer("(").get_next_token().type, "LPARENTHESIS")
-
-    def test_closing_parenthesis(self):
-        self.assertEqual(Lexer(")").get_next_token().type, "RPARENTHESIS")
-
-    def test_opening_square_bracket(self):
-        self.assertEqual(Lexer("[").get_next_token().type, "LBRACKET")
-
-    def test_closing_square_bracket(self):
-        self.assertEqual(Lexer("]").get_next_token().type, "RBRACKET")
+brackets = (
+    ('{', "LBRACE"),
+    ('}', "RBRACE"),
+    ("(", "LPARENTHESIS"),
+    (")", "RPARENTHESIS"),
+    ("[", "LBRACKET"),
+    ("]", "RBRACKET"),
+)
 
 
-if __name__ == "__main__":
-    unittest.main()
+@pytest.mark.parametrize("lexeme,name", brackets)
+def test_brackets_tokens(lexeme, name):
+    token = Lexer(File("<file>", lexeme)).get_next_token()
+    assert token.type == name

--- a/tests/lexer/char_constant_tokens_test.py
+++ b/tests/lexer/char_constant_tokens_test.py
@@ -1,42 +1,25 @@
-import unittest
+import pytest
 
-from norminette.lexer.lexer import Lexer
-from norminette.lexer.lexer import TokenError
+from norminette.file import File
+from norminette.lexer import Lexer, TokenError
 
-
-class CharConstTokenTest(unittest.TestCase):
-    def assertRaises(self, test):
-        try:
-            test()
-            return False
-        except TokenError:
-            return True
-
-    def test_basic_char(self):
-        self.assertEqual(Lexer("'*'").get_next_token().test(), "<CHAR_CONST='*'>")
-
-    def test_escaped_newline(self):
-        self.assertEqual(Lexer("'\\n'").get_next_token().test(), "<CHAR_CONST='\\n'>")
-
-    def test_octal_char(self):
-        self.assertEqual(
-            Lexer("'\\042'").get_next_token().test(), "<CHAR_CONST='\\042'>"
-        )
-
-    def test_hex_char(self):
-        self.assertEqual(
-            Lexer("'0x042'").get_next_token().test(), "<CHAR_CONST='0x042'>"
-        )
-
-    def test_error_newline_in_const(self):
-        self.assertRaises(Lexer("'\n1'").get_next_token)
-
-    def test_error_escaped_newline_followed_by_newline(self):
-        self.assertRaises(Lexer("'\\n\n'").get_next_token)
-
-    def test_error_unclosed_quote(self):
-        self.assertRaises(Lexer("'A").get_next_token)
+char_constants = (
+    ("'*'", "<CHAR_CONST='*'>"),
+    ("'\\n'", "<CHAR_CONST='\\n'>"),
+    ("'\\042'", "<CHAR_CONST='\\042'>"),
+    ("'0x042'", "<CHAR_CONST='0x042'>"),
+    ("'\n1'", None),
+    ("'\\n\n'", None),
+    ("'A", None),
+)
 
 
-if __name__ == "__main__":
-    unittest.main()
+@pytest.mark.parametrize("lexeme,expected", char_constants)
+def test_char_constants_tokens(lexeme, expected):
+    lexer = Lexer(File("<file>", lexeme))
+    if expected is None:
+        with pytest.raises(TokenError):
+            lexer.get_next_token()
+        return
+    token = lexer.get_next_token()
+    assert token.test() == expected

--- a/tests/lexer/constant_tokens_test.py
+++ b/tests/lexer/constant_tokens_test.py
@@ -22,7 +22,11 @@ constants = (
     ("42ll", "<CONSTANT=42ll>\n"),
     ("42ull", "<CONSTANT=42ull>\n"),
     ("42u", "<CONSTANT=42u>\n"),
-    ("-+-+-+-+-+-+-+-0Xe4Ae2", "<MINUS><PLUS><MINUS><PLUS><MINUS><PLUS><MINUS><PLUS><MINUS><PLUS><MINUS><PLUS><MINUS><PLUS><MINUS><CONSTANT=0Xe4Ae2>\n"),
+    (
+        "-+-+-+-+-+-+-+-0Xe4Ae2",
+        "<MINUS><PLUS><MINUS><PLUS><MINUS><PLUS><MINUS><PLUS><MINUS><PLUS>"
+        "<MINUS><PLUS><MINUS><PLUS><MINUS><CONSTANT=0Xe4Ae2>\n"
+    ),
     (".e42", "<DOT><IDENTIFIER=e42>\n"),
     ("4.4.4", None),
     ("4e4e4", None),

--- a/tests/lexer/constant_tokens_test.py
+++ b/tests/lexer/constant_tokens_test.py
@@ -1,104 +1,44 @@
-import unittest
+import pytest
 
-from norminette.lexer.lexer import Lexer
-from norminette.lexer.lexer import TokenError
+from norminette.file import File
+from norminette.lexer import Lexer, TokenError
 
-
-class ConstantTokensTest(unittest.TestCase):
-    def assertRaises(self, test):
-        try:
-            test()
-            return False
-        except TokenError:
-            return True
-
-    def test_basic_constant(self):
-        self.assertEqual(Lexer("42").check_tokens(), "<CONSTANT=42>\n")
-
-    def test_plus_sign_constant(self):
-        self.assertEqual(Lexer("+42").check_tokens(), "<PLUS><CONSTANT=42>\n")
-
-    def test_minus_sign_constant(self):
-        self.assertEqual(Lexer("-42").check_tokens(), "<MINUS><CONSTANT=42>\n")
-
-    def test_many_signs_constant(self):
-        self.assertEqual(Lexer("+-42").check_tokens(), "<PLUS><MINUS><CONSTANT=42>\n")
-
-    def test_decimal_constant(self):
-        self.assertEqual(Lexer("4.2").check_tokens(), "<CONSTANT=4.2>\n")
-
-    def test_decimal_constant_starting_with_dot(self):
-        self.assertEqual(Lexer(".42").check_tokens(), "<CONSTANT=.42>\n")
-
-    def test_exponential_constant(self):
-        self.assertEqual(Lexer("4e2").check_tokens(), "<CONSTANT=4e2>\n")
-
-    def test_exponential_constant_starting_with_dot(self):
-        self.assertEqual(Lexer(".4e2").check_tokens(), "<CONSTANT=.4e2>\n")
-
-    def test_float_exponential_constant_starting_with_dot(self):
-        self.assertEqual(Lexer("4e2f").check_tokens(), "<CONSTANT=4e2f>\n")
-
-    def test_float_exponential_constant(self):
-        self.assertEqual(Lexer(".4e2f").check_tokens(), "<CONSTANT=.4e2f>\n")
-
-    def test_octal_constant(self):
-        self.assertEqual(Lexer("042").check_tokens(), "<CONSTANT=042>\n")
-
-    def test_hex_constant(self):
-        self.assertEqual(Lexer("0x42").check_tokens(), "<CONSTANT=0x42>\n")
-
-    def test_hex_with_sign_constant(self):
-        self.assertEqual(Lexer("-0x4e2").check_tokens(), "<MINUS><CONSTANT=0x4e2>\n")
-
-    def test_hex_with_many_signs_constant(self):
-        self.assertEqual(
-            Lexer("-+-+-+-+-+-+-+-0Xe4Ae2").check_tokens(),
-            "<MINUS><PLUS><MINUS><PLUS><MINUS>"
-            + "<PLUS><MINUS><PLUS><MINUS><PLUS>"
-            + "<MINUS><PLUS><MINUS><PLUS><MINUS>"
-            + "<CONSTANT=0Xe4Ae2>\n",
-        )
-
-    def test_long_constant(self):
-        self.assertEqual(Lexer("42l").check_tokens(), "<CONSTANT=42l>\n")
-
-    def test_unsigned_long_constant(self):
-        self.assertEqual(Lexer("42ul").check_tokens(), "<CONSTANT=42ul>\n")
-
-    def test_long_long_constant(self):
-        self.assertEqual(Lexer("42ll").check_tokens(), "<CONSTANT=42ll>\n")
-
-    def test_unsigned_long_long_constant(self):
-        self.assertEqual(Lexer("42ull").check_tokens(), "<CONSTANT=42ull>\n")
-
-    def test_unsigned_constant(self):
-        self.assertEqual(Lexer("42u").check_tokens(), "<CONSTANT=42u>\n")
-
-    def test_error_too_many_dots(self):
-        self.assertRaises(Lexer("4.4.4").check_tokens)
-
-    def test_error_too_many_e(self):
-        self.assertRaises(Lexer("4e4e4").check_tokens)
-
-    def test_error_too_many_x(self):
-        self.assertRaises(Lexer("4x4x4").check_tokens)
-
-    def test_error_too_many_u(self):
-        self.assertRaises(Lexer("42uul").check_tokens)
-
-    def test_error_too_many_l(self):
-        self.assertRaises(Lexer("42Lllu").check_tokens)
-
-    def test_error_misplaced_l(self):
-        self.assertRaises(Lexer("42lul").check_tokens)
-
-    def test_misplaced_e(self):
-        self.assertEqual(Lexer(".e42").check_tokens(), "<DOT><IDENTIFIER=e42>\n")
-
-    def test_another_misplaced_e(self):
-        self.assertRaises(Lexer(".42e").check_tokens)
+constants = (
+    ("42", "<CONSTANT=42>\n"),
+    ("+42", "<PLUS><CONSTANT=42>\n"),
+    ("-42", "<MINUS><CONSTANT=42>\n"),
+    ("+-42", "<PLUS><MINUS><CONSTANT=42>\n"),
+    ("4.2", "<CONSTANT=4.2>\n"),
+    (".42", "<CONSTANT=.42>\n"),
+    ("4e2", "<CONSTANT=4e2>\n"),
+    (".4e2", "<CONSTANT=.4e2>\n"),
+    ("4e2f", "<CONSTANT=4e2f>\n"),
+    (".4e2f", "<CONSTANT=.4e2f>\n"),
+    ("042", "<CONSTANT=042>\n"),
+    ("0x42", "<CONSTANT=0x42>\n"),
+    ("-0x4e2", "<MINUS><CONSTANT=0x4e2>\n"),
+    ("42l", "<CONSTANT=42l>\n"),
+    ("42ul", "<CONSTANT=42ul>\n"),
+    ("42ll", "<CONSTANT=42ll>\n"),
+    ("42ull", "<CONSTANT=42ull>\n"),
+    ("42u", "<CONSTANT=42u>\n"),
+    ("-+-+-+-+-+-+-+-0Xe4Ae2", "<MINUS><PLUS><MINUS><PLUS><MINUS><PLUS><MINUS><PLUS><MINUS><PLUS><MINUS><PLUS><MINUS><PLUS><MINUS><CONSTANT=0Xe4Ae2>\n"),
+    (".e42", "<DOT><IDENTIFIER=e42>\n"),
+    ("4.4.4", None),
+    ("4e4e4", None),
+    ("4x4x4", None),
+    ("42uul", None),
+    ("42Lllu", None),
+    ("42lul", None),
+    (".42e", None),
+)
 
 
-if __name__ == "__main__":
-    unittest.main()
+@pytest.mark.parametrize("lexeme,expected", constants)
+def test_constants_tokens(lexeme, expected):
+    lexer = Lexer(File("<file>", lexeme))
+    if expected is None:
+        with pytest.raises(TokenError):
+            lexer.get_next_token()
+        return
+    assert lexer.check_tokens() == expected

--- a/tests/lexer/identifiers_tokens_test.py
+++ b/tests/lexer/identifiers_tokens_test.py
@@ -1,10 +1,11 @@
 import unittest
 
+from norminette.file import File
 from norminette.lexer.lexer import Lexer
 
 
 def eat_tokens(line):
-    lex = Lexer(line)
+    lex = Lexer(File("<file>", line))
     line = ""
     while lex.get_next_token():
         line += lex.peek_token().test()

--- a/tests/lexer/keywords_tokens_test.py
+++ b/tests/lexer/keywords_tokens_test.py
@@ -1,10 +1,11 @@
 import unittest
 
+from norminette.file import File
 from norminette.lexer.lexer import Lexer
 
 
 def eat_tokens(line):
-    lex = Lexer(line)
+    lex = Lexer(File("<file>", line))
     tokens = []
     while lex.get_next_token():
         tokens.append(lex.peek_token().test())

--- a/tests/lexer/operators_tokens_test.py
+++ b/tests/lexer/operators_tokens_test.py
@@ -1,128 +1,53 @@
-import unittest
+import pytest
 
-from norminette.lexer.lexer import Lexer
+from norminette.file import File
+from norminette.lexer import Lexer
+
+operators = (
+    (">>=", "RIGHT_ASSIGN"),
+    ("<<=", "LEFT_ASSIGN"),
+    ("+=", "ADD_ASSIGN"),
+    ("-=", "SUB_ASSIGN"),
+    ("*=", "MUL_ASSIGN"),
+    ("/=", "DIV_ASSIGN"),
+    ("%=", "MOD_ASSIGN"),
+    ("&=", "AND_ASSIGN"),
+    ("^=", "XOR_ASSIGN"),
+    ("|=", "OR_ASSIGN"),
+    ("<=", "LESS_OR_EQUAL"),
+    (">=", "GREATER_OR_EQUAL"),
+    ("==", "EQUALS"),
+    ("!=", "NOT_EQUAL"),
+    ("=", "ASSIGN"),
+    (";", "SEMI_COLON"),
+    (":", "COLON"),
+    (",", "COMMA"),
+    (".", "DOT"),
+    ("!", "NOT"),
+    ("-", "MINUS"),
+    ("+", "PLUS"),
+    ("*", "MULT"),
+    ("/", "DIV"),
+    ("%", "MODULO"),
+    ("<", "LESS_THAN"),
+    (">", "MORE_THAN"),
+    ("...", "ELLIPSIS"),
+    ("++", "INC"),
+    ("--", "DEC"),
+    ("->", "PTR"),
+    ("&&", "AND"),
+    ("||", "OR"),
+    ("^", "BWISE_XOR"),
+    ("|", "BWISE_OR"),
+    ("~", "BWISE_NOT"),
+    ("&", "BWISE_AND"),
+    (">>", "RIGHT_SHIFT"),
+    ("<<", "LEFT_SHIFT"),
+    ("?", "TERN_CONDITION"),
+)
 
 
-class TokensOperatorsTest(unittest.TestCase):
-    def test_op_right_assign(self):
-        self.assertEqual(Lexer(">>=").get_next_token().type, "RIGHT_ASSIGN")
-
-    def test_op_left_assign(self):
-        self.assertEqual(Lexer("<<=").get_next_token().type, "LEFT_ASSIGN")
-
-    def test_op_add_assign(self):
-        self.assertEqual(Lexer("+=").get_next_token().type, "ADD_ASSIGN")
-
-    def test_op_sub_assign(self):
-        self.assertEqual(Lexer("-=").get_next_token().type, "SUB_ASSIGN")
-
-    def test_op_mul_assign(self):
-        self.assertEqual(Lexer("*=").get_next_token().type, "MUL_ASSIGN")
-
-    def test_op_div_assign(self):
-        self.assertEqual(Lexer("/=").get_next_token().type, "DIV_ASSIGN")
-
-    def test_op_mod_assign(self):
-        self.assertEqual(Lexer("%=").get_next_token().type, "MOD_ASSIGN")
-
-    def test_op_and_assign(self):
-        self.assertEqual(Lexer("&=").get_next_token().type, "AND_ASSIGN")
-
-    def test_op_xor_assign(self):
-        self.assertEqual(Lexer("^=").get_next_token().type, "XOR_ASSIGN")
-
-    def test_op_or_assign(self):
-        self.assertEqual(Lexer("|=").get_next_token().type, "OR_ASSIGN")
-
-    def test_op_le_assign(self):
-        self.assertEqual(Lexer("<=").get_next_token().type, "LESS_OR_EQUAL")
-
-    def test_op_ge_assign(self):
-        self.assertEqual(Lexer(">=").get_next_token().type, "GREATER_OR_EQUAL")
-
-    def test_op_eq_assign(self):
-        self.assertEqual(Lexer("==").get_next_token().type, "EQUALS")
-
-    def test_op_ne_assign(self):
-        self.assertEqual(Lexer("!=").get_next_token().type, "NOT_EQUAL")
-
-    def test_op_assign(self):
-        self.assertEqual(Lexer("=").get_next_token().type, "ASSIGN")
-
-    def test_op_semi_colon(self):
-        self.assertEqual(Lexer(";").get_next_token().type, "SEMI_COLON")
-
-    def test_op_colon(self):
-        self.assertEqual(Lexer(":").get_next_token().type, "COLON")
-
-    def test_op_comma(self):
-        self.assertEqual(Lexer(",").get_next_token().type, "COMMA")
-
-    def test_op_dot(self):
-        self.assertEqual(Lexer(".").get_next_token().type, "DOT")
-
-    def test_op_not(self):
-        self.assertEqual(Lexer("!").get_next_token().type, "NOT")
-
-    def test_op_minus(self):
-        self.assertEqual(Lexer("-").get_next_token().type, "MINUS")
-
-    def test_op_plus(self):
-        self.assertEqual(Lexer("+").get_next_token().type, "PLUS")
-
-    def test_op_mult(self):
-        self.assertEqual(Lexer("*").get_next_token().type, "MULT")
-
-    def test_op_div(self):
-        self.assertEqual(Lexer("/").get_next_token().type, "DIV")
-
-    def test_op_modulo(self):
-        self.assertEqual(Lexer("%").get_next_token().type, "MODULO")
-
-    def test_op_less_than(self):
-        self.assertEqual(Lexer("<").get_next_token().type, "LESS_THAN")
-
-    def test_op_more_than(self):
-        self.assertEqual(Lexer(">").get_next_token().type, "MORE_THAN")
-
-    def test_op_ellipsis(self):
-        self.assertEqual(Lexer("...").get_next_token().type, "ELLIPSIS")
-
-    def test_op_inc(self):
-        self.assertEqual(Lexer("++").get_next_token().type, "INC")
-
-    def test_op_dec(self):
-        self.assertEqual(Lexer("--").get_next_token().type, "DEC")
-
-    def test_op_ptr(self):
-        self.assertEqual(Lexer("->").get_next_token().type, "PTR")
-
-    def test_op_and(self):
-        self.assertEqual(Lexer("&&").get_next_token().type, "AND")
-
-    def test_op_or(self):
-        self.assertEqual(Lexer("||").get_next_token().type, "OR")
-
-    def test_op_bwise_xor(self):
-        self.assertEqual(Lexer("^").get_next_token().type, "BWISE_XOR")
-
-    def test_op_bwise_or(self):
-        self.assertEqual(Lexer("|").get_next_token().type, "BWISE_OR")
-
-    def test_op_bwise_not(self):
-        self.assertEqual(Lexer("~").get_next_token().type, "BWISE_NOT")
-
-    def test_op_bwise_and(self):
-        self.assertEqual(Lexer("&").get_next_token().type, "BWISE_AND")
-
-    def test_op_right_shift(self):
-        self.assertEqual(Lexer(">>").get_next_token().type, "RIGHT_SHIFT")
-
-    def test_op_left_shift(self):
-        self.assertEqual(Lexer("<<").get_next_token().type, "LEFT_SHIFT")
-
-    def test_op_tern_condition(self):
-        self.assertEqual(Lexer("?").get_next_token().type, "TERN_CONDITION")
-
-    if __name__ == "__main__":
-        unittest.main()
+@pytest.mark.parametrize("operator,type", operators)
+def test_operators_tokens(operator, type):
+    token = Lexer(File("<file>", operator)).get_next_token()
+    assert token.type == type

--- a/tests/lexer/string_tokens_test.py
+++ b/tests/lexer/string_tokens_test.py
@@ -1,31 +1,17 @@
-import unittest
+import pytest
 
-from norminette.lexer.lexer import Lexer
+from norminette.file import File
+from norminette.lexer import Lexer
 
-
-class StringTokenTest(unittest.TestCase):
-    def test_basic_string(self):
-        self.assertEqual(
-            Lexer('"Basic string"').get_next_token().test(), '<STRING="Basic string">'
-        )
-
-    def test_basic_L_string(self):
-        self.assertEqual(
-            Lexer('L"Basic string"').get_next_token().test(), '<STRING=L"Basic string">'
-        )
-
-    def test_basic_escaped_string(self):
-        self.assertEqual(
-            Lexer('"Basic \\"string\\""').get_next_token().test(),
-            '<STRING="Basic \\"string\\"">',
-        )
-
-    def test_escaped_string(self):
-        self.assertEqual(
-            Lexer('"Escaped \\\\\\"string\\\\\\\\\\"\\\\"').get_next_token().test(),
-            '<STRING="Escaped \\\\\\"string\\\\\\\\\\"\\\\">',
-        )
+strings = (
+    ('"Basic string"', '<STRING="Basic string">'),
+    ('L"Basic string"', '<STRING=L"Basic string">'),
+    ('"Basic \\"string\\""', '<STRING="Basic \\"string\\"">'),
+    ('"Escaped \\\\\\"string\\\\\\\\\\"\\\\"', '<STRING="Escaped \\\\\\"string\\\\\\\\\\"\\\\">'),
+)
 
 
-if __name__ == "__main__":
-    unittest.main()
+@pytest.mark.parametrize("string,expected", strings)
+def test_string_tokens(string, expected):
+    token = Lexer(File("<file>", string)).get_next_token()
+    assert token.test() == expected

--- a/tests/rules/rules_generator_test.py
+++ b/tests/rules/rules_generator_test.py
@@ -1,6 +1,7 @@
 import pytest
 import glob
 
+from norminette.file import File
 from norminette.lexer import Lexer
 from norminette.context import Context
 from norminette.registry import Registry
@@ -18,9 +19,10 @@ def test_rule_for_file(file, capsys):
     with open(f"{file.split('.')[0]}.out") as out_file:
         out_content = out_file.read()
 
-    lexer = Lexer(file_to_lex)
-    context = Context(file.split("/")[-1], lexer.get_tokens(), debug=2)
-    registry.run(context, file_to_lex)
+    file = File(file, file_to_lex)
+    lexer = Lexer(file)
+    context = Context(file, lexer.get_tokens(), debug=2)
+    registry.run(context)
     captured = capsys.readouterr()
 
     assert captured.out == out_content

--- a/tests/tokenizer/token_errors_test.py
+++ b/tests/tokenizer/token_errors_test.py
@@ -1,5 +1,6 @@
 import pytest
 
+from norminette.file import File
 from norminette.lexer import Lexer, TokenError
 
 
@@ -45,4 +46,4 @@ def test_tokenizing_errors(data):
     text, line, pos = data.values()
 
     with pytest.raises(TokenError, match=f"({line}, {pos})"):
-        Lexer(text).check_tokens()
+        Lexer(File("<file>", text)).check_tokens()

--- a/tests/tokenizer/token_generator_test.py
+++ b/tests/tokenizer/token_generator_test.py
@@ -12,9 +12,6 @@ test_files = glob.glob("tests/tokenizer/samples/ok/*.[ch]")
 
 @pytest.mark.parametrize("file", test_files)
 def test_rule_for_file(file):
-    with open(file, "r") as test_file:
-        file_to_lex = test_file.read()
-
     with open(f"{file.split('.')[0]}.tokens") as out_file:
         out_content = out_file.read()
 

--- a/tests/tokenizer/token_generator_test.py
+++ b/tests/tokenizer/token_generator_test.py
@@ -1,6 +1,7 @@
 import pytest
 import glob
 
+from norminette.file import File
 from norminette.lexer import Lexer
 from norminette.registry import Registry
 
@@ -17,6 +18,6 @@ def test_rule_for_file(file):
     with open(f"{file.split('.')[0]}.tokens") as out_file:
         out_content = out_file.read()
 
-    output = Lexer(file_to_lex).check_tokens()
+    output = Lexer(File(file)).check_tokens()
 
     assert output == out_content


### PR DESCRIPTION
- Add `File` class (can be used to store attributes like `source`, `tokens`, `errors`, `include`, etc.)
- Add `Errors` class (can be used in `Lexer` to avoid exceptions exiting the norminette)
- Rewrite lexer tests to `pytest` with `parametrize` fixture
- Remove old/unused code in `__main__.py`