### PR TITLE
add more information in 'norminette --version' command

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -15,9 +15,7 @@ Please use markdown to send the code here.
 
 
 **Additional infos**
- - OS:
- - python3 --version:
- - norminette -v:
+Copy and paste the output of `norminette --version` command here.
 
 **Additional context**
 Add any other context about the problem here.

--- a/norminette/__init__.py
+++ b/norminette/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.3.54"
+__version__ = "3.3.55"
 __name__ = "norminette"
 __author__ = "42"
 __author__email__ = "pedago@42.fr"

--- a/norminette/__main__.py
+++ b/norminette/__main__.py
@@ -1,6 +1,7 @@
 import glob
 import sys
 import pathlib
+import platform
 from importlib.metadata import version
 
 import argparse
@@ -12,6 +13,10 @@ from norminette.context import Context
 from norminette.tools.colors import colors
 
 import subprocess
+
+version_text = "norminette" + version("norminette")
+version_text += f", Python {platform.python_version()}"
+version_text += f", {platform.platform()}"
 
 
 def main():
@@ -39,7 +44,7 @@ def main():
         "-v",
         "--version",
         action="version",
-        version="norminette " + version("norminette"),
+        version=version_text,
     )
     parser.add_argument(
         "--cfile",


### PR DESCRIPTION
The version of norminette in package differs from the `pyproject.toml`. Fixed in eb78a9e9f2c5ea2fc74ab74f577003357c0efcd1.

```
$ norminette --version
norminette3.3.54, Python 3.10.12, Linux-5.15.133.1-microsoft-standard-WSL2-x86_64-with-glibc2.35
```