### PR TITLE
Change error displaying and add colors!

### DIFF
--- a/norminette/errors.py
+++ b/norminette/errors.py
@@ -149,8 +149,13 @@ class Errors:
         return "OK" if all(it.level == "Notice" for it in self._inner) else "Error"
 
     @property
-    def has_notice(self) -> bool:
-        return any(it.level == "Notice" for it in self._inner)
+    def colorful_status(self) -> str:
+        if self.status == "OK":
+            if any(it.level == "Notice" for it in self._inner):
+                return "\033[93m[OK]\033[0m"
+            return "\033[92m[OK]\033[0m"
+        return "\033[91m[KO]\033[0m"
+
 
     def append(self, value: Union[NormError, NormWarning]) -> None:
         # TODO Remove NormError and NormWarning since it does not provide `length` data
@@ -185,10 +190,7 @@ class HumanizedErrorsFormatter(_formatter):
 
         output = ''
         for file in self.files:
-            status = file.errors.status
-            if status == "OK" and file.errors.has_notice:
-                status = "Notice"
-            output += colorize(status, f"[{'KO' if status == 'Error' else 'OK'}]")
+            output += file.errors.colorful_status
             output += f" {file.basename}"
             for error in file.errors:
                 highlight = error.highlights[0]

--- a/norminette/errors.py
+++ b/norminette/errors.py
@@ -156,7 +156,6 @@ class Errors:
             return "\033[92m[OK]\033[0m"
         return "\033[91m[KO]\033[0m"
 
-
     def append(self, value: Union[NormError, NormWarning]) -> None:
         # TODO Remove NormError and NormWarning since it does not provide `length` data
         assert isinstance(value, (NormError, NormWarning))


### PR DESCRIPTION
#294 is already providing something but it seems that it's not compatible with the changes made to the output code after the last released version (3.3.55), so I made a version which can directly be merged into master.

Obvious from the title: these changes make the norm error hunting colorful (also easier but that's just a side effect)

## Summary

The `OK!` and `Error!` are put at the left of the file names as `[OK]` and `[KO]`. This way they are aligned and easier to read.

The `[OK]` and `[KO]` are colored in red and green. The `Error:` lines are red. The `Notice:` lines are yellow. This way, seeing a lot of errors is even scarier than before.

## About the tests
I have no idea how they work, so um if there is something to change, could someone help me on that or send me docs?