### PR TITLE
Fix Dockerfile python version and dependencies installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,16 @@
-FROM python:3.7-alpine
+FROM python:3.12-alpine
 
 WORKDIR /usr/src/norminette
 
+COPY pyproject.toml poetry.lock ./
+
+RUN pip3 install poetry \
+    && poetry config virtualenvs.create false \
+    && poetry install --no-dev
+
 COPY . .
 
-RUN pip3 install -r requirements.txt \
-	&& python3 setup.py install
+RUN python3 setup.py install
 
 WORKDIR /code
 

--- a/README.md
+++ b/README.md
@@ -67,13 +67,13 @@ norminette -dd
 ```
 docker build -t norminette .
 cd ~/42/ft_printf
-docker run -v $PWD:/code norminette /code
+docker run --rm -v $PWD:/code norminette
 ```
 
 If you encounter an error or an incorrect output, you can:
- - Open an issue on github 
+ - Open an issue on github
  - Post a message on the dedicated slack channel (#norminette-v3-beta)
-    
+
 
 Please try to include as much information as possible (the file on which it crashed, etc)
 


### PR DESCRIPTION
**Problem:** The Docker configuration for running norminette is not working out of the box.
- Following [PR #380](https://github.com/42School/norminette/pull/380), the minimum required version of `Python is 3.8`, but the Docker container was using `Python 3.7`.
- Dependencies are now managed by `Poetry` instead of a plain `requirements.txt` file (which has been removed, yet still referenced in the Dockerfile).
- Running the command stated in the `README` creates a new container each time, leaving unused containers behind.

**Solution:**
- Updated the Python version in the `Dockerfile` to the latest stable version (3.12).
- Updated the `Dockerfile` to use Poetry for dependency management.
- Added the `--rm` flag to the Docker run command in the `README` to automatically remove the container after execution.