### PR TITLE
fix(docker): Fix dockerfile poetry installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-alpine
+FROM python:3.12-slim
 
 WORKDIR /usr/src/norminette
 


### PR DESCRIPTION
The previous PR https://github.com/42School/norminette/pull/500 changes had a problem with the Dockerfile where `poetry` couldn't be installed.

The fix was either to keep the `-alpine` version of Python, but install `gcc`, `libc-dev` and `libggi-dev` to be able to install `poetry`, or use the `-slim` that already had everything it needed.

I chose the "change the image" option, because in the end the final image was lighter (283MB vs 350MB)