### PR TITLE
improve readability of SPACE_BEFORE_FUNC error message

### DIFF
--- a/norminette/norm_error.py
+++ b/norminette/norm_error.py
@@ -16,7 +16,7 @@ errors = {
     "SPC_AFTER_POINTER": "space after pointer",
     "SPC_LINE_START": "Unexpected space/tab at line start",
     "SPC_BFR_POINTER": "bad spacing before pointer",
-    "SPACE_BEFORE_FUNC": "space before function name",
+    "SPACE_BEFORE_FUNC": "Found space when expecting tab before function name",
     "TOO_MANY_TABS_FUNC": "extra tabs before function name",
     "TOO_MANY_TABS_TD": "extra tabs before typedef name",
     "MISSING_TAB_FUNC": "missing tab before function name",

--- a/tests/rules/samples/ko_func_name2.out
+++ b/tests/rules/samples/ko_func_name2.out
@@ -44,7 +44,7 @@ ko_func_name2.c: Error!
 Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
 Error: EXP_PARENTHESIS      (line:   1, col:   9):	Expected parenthesis
 Error: EXP_PARENTHESIS      (line:   6, col:   9):	Expected parenthesis
-Error: SPACE_BEFORE_FUNC    (line:  11, col:   4):	space before function name
+Error: SPACE_BEFORE_FUNC    (line:  11, col:   4):	Found space when expecting tab before function name
 Error: EXP_PARENTHESIS      (line:  11, col:   9):	Expected parenthesis
 Error: TOO_FEW_TAB          (line:  13, col:   1):	Missing tabs for indent level
 Error: SPACE_REPLACE_TAB    (line:  13, col:   5):	Found space when expecting tab
@@ -52,4 +52,4 @@ Error: SPACE_REPLACE_TAB    (line:  13, col:   8):	Found space when expecting ta
 Error: DECL_ASSIGN_LINE     (line:  13, col:  17):	Declaration and assignation on a single line
 Error: TOO_FEW_TAB          (line:  15, col:   1):	Missing tabs for indent level
 Error: SPACE_REPLACE_TAB    (line:  15, col:   5):	Found space when expecting tab
-Error: SPACE_BEFORE_FUNC    (line:  18, col:  11):	space before function name
+Error: SPACE_BEFORE_FUNC    (line:  18, col:  11):	Found space when expecting tab before function name

--- a/tests/rules/samples/long_test.out
+++ b/tests/rules/samples/long_test.out
@@ -148,7 +148,7 @@ Error: TOO_MANY_TAB         (line:   4, col:   1):	Extra tabs for indent level
 Error: EMPTY_LINE_FUNCTION  (line:   5, col:   1):	Empty line in function
 Error: SPACE_EMPTY_LINE     (line:   5, col:   1):	Space on empty line
 Error: TOO_FEW_TAB          (line:   6, col:   1):	Missing tabs for indent level
-Error: SPACE_BEFORE_FUNC    (line:  10, col:  10):	space before function name
+Error: SPACE_BEFORE_FUNC    (line:  10, col:  10):	Found space when expecting tab before function name
 Error: NO_ARGS_VOID         (line:  10, col:  13):	Empty function argument requires void
 Error: BRACE_NEWLINE        (line:  10, col:  15):	Expected newline before brace
 Error: BRACE_SHOULD_EOL     (line:  10, col:  16):	Expected newline after brace
@@ -157,13 +157,13 @@ Error: TOO_FEW_TAB          (line:  10, col:  17):	Missing tabs for indent level
 Error: TOO_MANY_INSTR       (line:  10, col:  17):	Too many instructions on a single line
 Error: RETURN_PARENTHESIS   (line:  10, col:  24):	Return value must be in parenthesis
 Error: TOO_MANY_INSTR       (line:  10, col:  27):	Too many instructions on a single line
-Error: SPACE_BEFORE_FUNC    (line:  12, col:   4):	space before function name
+Error: SPACE_BEFORE_FUNC    (line:  12, col:   4):	Found space when expecting tab before function name
 Error: RETURN_PARENTHESIS   (line:  14, col:  12):	Return value must be in parenthesis
 Error: INCLUDE_START_FILE   (line:  17, col:   1):	Include must be at the start of file
 Error: NL_AFTER_PREPROC     (line:  18, col:   1):	Preprocessor statement must be followed by a newline
 Error: NO_ARGS_VOID         (line:  18, col:  11):	Empty function argument requires void
 Error: RETURN_PARENTHESIS   (line:  20, col:  12):	Return value must be in parenthesis
-Error: SPACE_BEFORE_FUNC    (line:  23, col:   4):	space before function name
+Error: SPACE_BEFORE_FUNC    (line:  23, col:   4):	Found space when expecting tab before function name
 Error: MISSING_IDENTIFIER   (line:  23, col:  16):	missing type qualifier or identifier in function arguments
 Error: BRACE_NEWLINE        (line:  23, col:  22):	Expected newline before brace
 Error: RETURN_PARENTHESIS   (line:  24, col:  12):	Return value must be in parenthesis

--- a/tests/rules/samples/test_comment_escaping_with_backslash.out
+++ b/tests/rules/samples/test_comment_escaping_with_backslash.out
@@ -22,7 +22,7 @@
 		<MULT_COMMENT=/**/> 
 test_comment_escaping_with_backslash.c: Error!
 Error: INVALID_HEADER       (line:   3, col:   1):	Missing or invalid 42 header
-Error: SPACE_BEFORE_FUNC    (line:   6, col:   4):	space before function name
+Error: SPACE_BEFORE_FUNC    (line:   6, col:   4):	Found space when expecting tab before function name
 Error: NO_ARGS_VOID         (line:   6, col:  10):	Empty function argument requires void
 Error: BRACE_NEWLINE        (line:   6, col:  12):	Expected newline before brace
 Error: TOO_FEW_TAB          (line:   7, col:   1):	Missing tabs for indent level

--- a/tests/rules/samples/test_comment_escaping_with_trigraph.out
+++ b/tests/rules/samples/test_comment_escaping_with_trigraph.out
@@ -22,7 +22,7 @@
 		<MULT_COMMENT=/**/> 
 test_comment_escaping_with_trigraph.c: Error!
 Error: INVALID_HEADER       (line:   3, col:   1):	Missing or invalid 42 header
-Error: SPACE_BEFORE_FUNC    (line:   6, col:   4):	space before function name
+Error: SPACE_BEFORE_FUNC    (line:   6, col:   4):	Found space when expecting tab before function name
 Error: NO_ARGS_VOID         (line:   6, col:  10):	Empty function argument requires void
 Error: BRACE_NEWLINE        (line:   6, col:  12):	Expected newline before brace
 Error: TOO_FEW_TAB          (line:   7, col:   1):	Missing tabs for indent level

--- a/tests/rules/samples/test_comments.out
+++ b/tests/rules/samples/test_comments.out
@@ -63,7 +63,7 @@ Error: SPACE_REPLACE_TAB    (line:  10, col:   5):	Found space when expecting ta
 Error: CONSECUTIVE_SPC      (line:  10, col:  11):	Two or more consecutives spaces
 Error: SPACE_REPLACE_TAB    (line:  11, col:   5):	Found space when expecting tab
 Error: TOO_FEW_TAB          (line:  11, col:  16):	Missing tabs for indent level
-Error: SPACE_BEFORE_FUNC    (line:  14, col:   5):	space before function name
+Error: SPACE_BEFORE_FUNC    (line:  14, col:   5):	Found space when expecting tab before function name
 Error: COMMENT_ON_INSTR     (line:  14, col:  12):	Comment must be on its own line or at end of a line
 Error: MISSING_IDENTIFIER   (line:  14, col:  25):	missing type qualifier or identifier in function arguments
 Error: SPACE_EMPTY_LINE     (line:  16, col:   4):	Space on empty line

--- a/tests/rules/samples/test_file_0924.out
+++ b/tests/rules/samples/test_file_0924.out
@@ -24,7 +24,7 @@
 		<NEWLINE>
 test_file_0924.c: Error!
 Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
-Error: SPACE_BEFORE_FUNC    (line:   1, col:   5):	space before function name
+Error: SPACE_BEFORE_FUNC    (line:   1, col:   5):	Found space when expecting tab before function name
 Error: BRACE_NEWLINE        (line:   1, col:  47):	Expected newline before brace
 Error: TOO_MANY_TAB         (line:   5, col:   1):	Extra tabs for indent level
 Error: BRACE_SHOULD_EOL     (line:   5, col:  13):	Expected newline after brace

--- a/tests/rules/samples/test_file_210412.out
+++ b/tests/rules/samples/test_file_210412.out
@@ -38,5 +38,5 @@
 		<RBRACE> 
 test_file_210412.c: Error!
 Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
-Error: SPACE_BEFORE_FUNC    (line:  14, col:   4):	space before function name
+Error: SPACE_BEFORE_FUNC    (line:  14, col:   4):	Found space when expecting tab before function name
 Error: BRACE_SHOULD_EOL     (line:  21, col:   1):	Expected newline after brace


### PR DESCRIPTION
I have been using the norminette in the piscine, and the `SPACE_BEFORE_FUNC` error message was a little hard to understand.
it confuses me a lot of times whether "I should use the space" or "the space is what is causing the problem". 

## Change : 

**Before** : `space before function name` 
**After**    : `Found space when expecting tab before function name`

## Note : 
I apply the changes to the testing files as well.

Thanks for your time.