### PR TITLE
Fix Docker build by explicitly installing `setuptools`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /usr/src/norminette
 
 COPY pyproject.toml poetry.lock ./
 
-RUN pip3 install poetry \
+RUN pip3 install setuptools poetry \
     && poetry config virtualenvs.create false \
     && poetry install --no-dev
 


### PR DESCRIPTION
## Issues fixed
This PR fixes a Docker build issue where the `setuptools` package was missing, causing the `python3 setup.py install` step to fail.

#### Problem:
The build process was failing at the step where `setup.py` attempts to run the installation, throwing the following error:

```
ModuleNotFoundError: No module named 'setuptools'
```
<img width="810" alt="Screenshot 2024-09-07 at 21 07 10" src="https://github.com/user-attachments/assets/6d16db0c-d8ed-4c59-9547-00eee2e73814">



#### Solution:
Added `setuptools` installation as part of the Docker build process to ensure that the package is available when running `python3 setup.py install`.

### Testing:
- Successfully built the Docker image without errors after the change.
 <img width="802" alt="Screenshot 2024-09-07 at 21 05 58" src="https://github.com/user-attachments/assets/76050edf-a4a1-4e0d-b7c8-12eb81832765">
