### PR TITLE
Update Dockerfile to use new poetry option --without dev 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,12 @@ FROM python:3.12-slim
 
 WORKDIR /usr/src/norminette
 
-COPY pyproject.toml poetry.lock ./
+COPY pyproject.toml poetry.lock README.md ./
+COPY norminette ./norminette
 
-RUN pip3 install setuptools poetry \
+RUN pip3 install poetry \
     && poetry config virtualenvs.create false \
-    && poetry install --no-dev
-
-COPY . .
-
-RUN python3 setup.py install
+    && poetry install --without dev
 
 WORKDIR /code
 


### PR DESCRIPTION
The option --no-dev was deprecated on poetry 2.0.0, also there are other breaking changes that I'm not able to quickly fix. So locking the version is what I can do.

https://github.com/python-poetry/poetry/pull/8659