### PR TITLE
Handle defined operator in #if and #elif directives

### DIFF
--- a/norminette/rules/is_preprocessor_statement.py
+++ b/norminette/rules/is_preprocessor_statement.py
@@ -315,17 +315,13 @@ class ConstantExpressionParser:
             self.parse_potential_binary_operator()
             return
 
-        if self.context.check_token(self.index, UNARY_OPERATORS):
-            self.index += 1
-            self.parse_expression()
-            return
-
         if (
-                self.directive in ["if", "elif"]
-                and self.context.check_token(self.index, "IDENTIFIER")
-                and self.context.peek_token(self.index).value == "defined"
+                self.context.check_token(self.index, UNARY_OPERATORS)
+                or (
+                    self.context.check_token(self.index, "IDENTIFIER")
+                    and self.context.peek_token(self.index).value == "defined"
+                )
         ):
-            """Handles 'defined' operator within #if directive"""
             self.index += 1
             self.skip_ws()
             self.parse_expression()

--- a/norminette/rules/is_preprocessor_statement.py
+++ b/norminette/rules/is_preprocessor_statement.py
@@ -320,6 +320,17 @@ class ConstantExpressionParser:
             self.parse_expression()
             return
 
+        if (
+                self.directive in ["if", "elif"]
+                and self.context.check_token(self.index, "IDENTIFIER")
+                and self.context.peek_token(self.index).value == "defined"
+        ):
+            """Handles 'defined' operator within #if directive"""
+            self.index += 1
+            self.skip_ws()
+            self.parse_expression()
+            return
+
         if self.context.check_token(self.index, "IDENTIFIER"):
             self.index += 1
             if self.context.check_token(self.index, "LPARENTHESIS"):

--- a/tests/rules/samples/ok_if_defined.c
+++ b/tests/rules/samples/ok_if_defined.c
@@ -1,0 +1,9 @@
+#if defined FOO
+# undef FOO
+#elif defined (BAR)
+# undef BAR
+#elif defined(FOOBAR)
+# undef FOOBAR
+#endif /* if defined FOO */
+
+void	defined(void);

--- a/tests/rules/samples/ok_if_defined.c
+++ b/tests/rules/samples/ok_if_defined.c
@@ -6,4 +6,6 @@
 # undef FOOBAR
 #endif /* if defined FOO */
 
+#define A defined B
+
 void	defined(void);

--- a/tests/rules/samples/ok_if_defined.out
+++ b/tests/rules/samples/ok_if_defined.out
@@ -1,0 +1,20 @@
+[36mok_if_defined.c[0m - [32mIsPreprocessorStatement[0m In "GlobalScope" from "None" line 1":
+		<HASH> <IF> <SPACE> <IDENTIFIER=defined> <SPACE> <IDENTIFIER=FOO> <NEWLINE>
+[36mok_if_defined.c[0m - [32mIsPreprocessorStatement[0m In "GlobalScope" from "None" line 2":
+		<HASH> <SPACE> <IDENTIFIER=undef> <SPACE> <IDENTIFIER=FOO> <NEWLINE>
+[36mok_if_defined.c[0m - [32mIsPreprocessorStatement[0m In "GlobalScope" from "None" line 3":
+		<HASH> <IDENTIFIER=elif> <SPACE> <IDENTIFIER=defined> <SPACE> <LPARENTHESIS> <IDENTIFIER=BAR> <RPARENTHESIS> <NEWLINE>
+[36mok_if_defined.c[0m - [32mIsPreprocessorStatement[0m In "GlobalScope" from "None" line 4":
+		<HASH> <SPACE> <IDENTIFIER=undef> <SPACE> <IDENTIFIER=BAR> <NEWLINE>
+[36mok_if_defined.c[0m - [32mIsPreprocessorStatement[0m In "GlobalScope" from "None" line 5":
+		<HASH> <IDENTIFIER=elif> <SPACE> <IDENTIFIER=defined> <LPARENTHESIS> <IDENTIFIER=FOOBAR> <RPARENTHESIS> <NEWLINE>
+[36mok_if_defined.c[0m - [32mIsPreprocessorStatement[0m In "GlobalScope" from "None" line 6":
+		<HASH> <SPACE> <IDENTIFIER=undef> <SPACE> <IDENTIFIER=FOOBAR> <NEWLINE>
+[36mok_if_defined.c[0m - [32mIsPreprocessorStatement[0m In "GlobalScope" from "None" line 7":
+		<HASH> <IDENTIFIER=endif> <SPACE> <MULT_COMMENT=/* if defined FOO */> <NEWLINE>
+[36mok_if_defined.c[0m - [32mIsEmptyLine[0m In "GlobalScope" from "None" line 8":
+		<NEWLINE>
+[36mok_if_defined.c[0m - [32mIsFuncPrototype[0m In "GlobalScope" from "None" line 9":
+		<VOID> <TAB> <IDENTIFIER=defined> <LPARENTHESIS> <VOID> <RPARENTHESIS> <SEMI_COLON> <NEWLINE>
+ok_if_defined.c: Error!
+Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m

--- a/tests/rules/samples/ok_if_defined.out
+++ b/tests/rules/samples/ok_if_defined.out
@@ -14,7 +14,12 @@
 		<HASH> <IDENTIFIER=endif> <SPACE> <MULT_COMMENT=/* if defined FOO */> <NEWLINE>
 [36mok_if_defined.c[0m - [32mIsEmptyLine[0m In "GlobalScope" from "None" line 8":
 		<NEWLINE>
-[36mok_if_defined.c[0m - [32mIsFuncPrototype[0m In "GlobalScope" from "None" line 9":
+[36mok_if_defined.c[0m - [32mIsPreprocessorStatement[0m In "GlobalScope" from "None" line 9":
+		<HASH> <IDENTIFIER=define> <SPACE> <IDENTIFIER=A> <SPACE> <IDENTIFIER=defined> <SPACE> <IDENTIFIER=B> <NEWLINE>
+[36mok_if_defined.c[0m - [32mIsEmptyLine[0m In "GlobalScope" from "None" line 10":
+		<NEWLINE>
+[36mok_if_defined.c[0m - [32mIsFuncPrototype[0m In "GlobalScope" from "None" line 11":
 		<VOID> <TAB> <IDENTIFIER=defined> <LPARENTHESIS> <VOID> <RPARENTHESIS> <SEMI_COLON> <NEWLINE>
 ok_if_defined.c: Error!
 Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
+Error: PREPROC_CONSTANT     (line:   9, col:  19):	[0mPreprocessor statement must only contain constant defines[0m


### PR DESCRIPTION
## Issues fixed 
Fixes 42School/norminette#499

## Verification
- Added 1 new test file
- Unit tests don't all pass, but modifications don't cause any additional failures
- Modifications pass flake8

## Notes 
The solution implemented treats defined identifier as unary operator when found within if and elif directives.
Since these directives are the only places where the word defined has a special meaning it seems unnecessary to change the dictionary or tokenizer.
The solution doesn't check if the operand is syntactically sound, but that doesn't seem necessary to assess norm adherence.