### PR TITLE
Add --no-colors flag and fix #492 regressions

### DIFF
--- a/norminette/__main__.py
+++ b/norminette/__main__.py
@@ -74,6 +74,7 @@ def main():
         help="formatting style for errors",
         default="humanized",
     )
+    parser.add_argument("--no-colors", action="store_true", help="Disable colors in output")
     parser.add_argument("-R", nargs=1, help="compatibility for norminette 2")
     args = parser.parse_args()
     registry = Registry()
@@ -135,7 +136,7 @@ def main():
             sys.exit(1)
         except KeyboardInterrupt:
             sys.exit(1)
-    errors = format(files)
+    errors = format(files, use_colors=not args.no_colors)
     print(errors, end='')
     sys.exit(1 if len(file.errors) else 0)
 

--- a/norminette/colors.py
+++ b/norminette/colors.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 red = {
     "TOO_MANY_ARGS",
     "TOO_MANY_VARS_FUNC",
@@ -42,3 +44,19 @@ grey = {
     "INVALID_HEADER",
     "WRONG_SCOPE_COMMENT",
 }
+
+_color_table = {
+    "91": red,
+    "92": green,
+    "93": yellow,
+    "94": blue,
+    "95": pink,
+    "97": grey,
+}
+
+
+def error_color(name: str) -> Optional[str]:
+    for color, table in _color_table.items():
+        if name in table:
+            return color
+    return None

--- a/norminette/context.py
+++ b/norminette/context.py
@@ -1,7 +1,8 @@
 from dataclasses import dataclass, field
 
+from norminette.errors import Error, Highlight
+from norminette.lexer import Token
 from norminette.exceptions import CParsingError
-from norminette.norm_error import NormError, NormWarning
 from norminette.scope import GlobalScope, ControlStructure
 from norminette.tools.colors import colors
 
@@ -241,14 +242,15 @@ class Context:
                 return i
         return -1
 
-    def new_error(self, errno, tkn):
-        pos = tkn
-        if not isinstance(tkn, (tuple, list)):
-            pos = tkn.pos
-        self.errors.append(NormError(errno, pos[0], pos[1]))
+    def new_error(self, errno, tkn: Token):
+        # XXX Deprecated, use `.errors` and `norminette.errors` module.
+        error = Error.from_name(errno, highlights=[Highlight.from_token(tkn)])
+        self.errors.add(error)
 
-    def new_warning(self, errno, tkn):
-        self.errors.append(NormWarning(errno, tkn.pos[0], tkn.pos[1]))
+    def new_warning(self, errno, tkn: Token):
+        # XXX Deprecated, use `.errors` and `norminette.errors` module.
+        error = Error.from_name(errno, level="Notice", highlights=[Highlight.from_token(tkn)])
+        self.errors.append(error)
 
     def get_parent_rule(self):
         if len(self.history) == 0:

--- a/norminette/lexer/tokens.py
+++ b/norminette/lexer/tokens.py
@@ -13,6 +13,20 @@ class Token:
         return len(self.value or '')
 
     @property
+    def unsafe_length(self) -> Optional[int]:
+        if self.value is None:
+            return None
+        return self.length
+
+    @property
+    def lineno(self) -> int:
+        return self.pos[0]
+
+    @property
+    def column(self) -> int:
+        return self.pos[1]
+
+    @property
     def line_column(self):
         return self.pos[1]
 

--- a/norminette/norm_error.py
+++ b/norminette/norm_error.py
@@ -1,5 +1,3 @@
-from norminette.colors import red, blue, yellow, pink, grey, green
-
 errors = {
     "SPC_INSTEAD_TAB": "Spaces at beginning of line",
     "TAB_INSTEAD_SPC": "Found tab when expecting space",
@@ -142,45 +140,3 @@ digits or '_'",
     "MULTIPLE_DOTS": "Multiple dots in float constant",
     "MULTIPLE_X": "Multiple 'x' in hexadecimal float constant",
 }
-
-
-class NormError:
-    def __init__(self, errno, line, col):
-        self.errno = errno
-        self.line = line
-        self.col = col
-        self.error_pos = f"(line: {(str(self.line)).rjust(3)}, col: {(str(self.col)).rjust(3)}):\t"
-        self.prefix = f"Error: {self.errno:<20} {self.error_pos:>21}"
-        self.error_msg = f"{errors.get(self.errno, 'ERROR NOT FOUND')}"
-        self.no_color = "\033[0m"
-        self.color = self.no_color
-        color = {
-                "\033[91m": red,
-                "\033[92m": green,
-                "\033[93m": yellow,
-                "\033[94m": blue,
-                "\033[95m": pink,
-                "\033[97m": grey,
-        }
-        for key, value in color.items():
-            if errno in value:
-                self.color = key
-                break
-        self.prefix = self.prefix
-        self.error_msg = self.color + self.error_msg + self.no_color
-
-    def __str__(self):
-        return self.prefix + self.error_msg
-
-
-class NormWarning:
-    def __init__(self, errno, line, col):
-        self.errno = errno
-        self.line = line
-        self.col = col
-        self.error_pos = f"(line: {(str(self.line)).rjust(3)}, col: {(str(self.col)).rjust(3)}):\t"
-        self.prefix = f"Notice: {self.errno:<20} {self.error_pos:>21}"
-        self.error_msg = f"{errors.get(self.errno, 'WARNING NOT FOUND')}"
-
-    def __str__(self):
-        return self.prefix + self.error_msg

--- a/tests/rules/rules_generator_test.py
+++ b/tests/rules/rules_generator_test.py
@@ -24,7 +24,7 @@ def test_rule_for_file(file, capsys):
     lexer = Lexer(file)
     context = Context(file, list(lexer), debug=2)
     registry.run(context)
-    errors = HumanizedErrorsFormatter(file)
+    errors = HumanizedErrorsFormatter(file, use_colors=False)
     print(errors, end='')
     captured = capsys.readouterr()
 

--- a/tests/rules/samples/check_attributes.out
+++ b/tests/rules/samples/check_attributes.out
@@ -26,6 +26,6 @@
 [36mcheck_attributes.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 14":
 		<RBRACE> <NEWLINE>
 check_attributes.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: ATTR_EOL             (line:   6, col:   7):	[0mFunction attribute must be at the end of line[0m
-Error: MISALIGNED_FUNC_DECL (line:   6, col:  37):	[0mMisaligned function declaration[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: ATTR_EOL             (line:   6, col:   7):	Function attribute must be at the end of line
+Error: MISALIGNED_FUNC_DECL (line:   6, col:  37):	Misaligned function declaration

--- a/tests/rules/samples/check_preprocessor_define.out
+++ b/tests/rules/samples/check_preprocessor_define.out
@@ -67,25 +67,25 @@
 [36mcheck_preprocessor_define.c[0m - [32mIsPreprocessorStatement[0m In "GlobalScope" from "None" line 35":
 		<HASH> <IDENTIFIER=define> <SPACE> <IDENTIFIER=B> <SPACE> <CHAR_CONST='a'> 
 check_preprocessor_define.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: MACRO_NAME_CAPITAL   (line:   1, col:   9):	[0mMacro name must be capitalized[0m
-Error: MACRO_NAME_CAPITAL   (line:   3, col:   9):	[0mMacro name must be capitalized[0m
-Error: CONSECUTIVE_WS       (line:   5, col:   8):	[94mTwo or more consecutives white spaces[0m
-Error: CONSECUTIVE_WS       (line:   6, col:   8):	[94mTwo or more consecutives white spaces[0m
-Error: TAB_REPLACE_SPACE    (line:   6, col:   8):	[0mFound tab when expecting space[0m
-Error: MACRO_NAME_CAPITAL   (line:   6, col:  13):	[0mMacro name must be capitalized[0m
-Error: CONSECUTIVE_WS       (line:   7, col:   8):	[94mTwo or more consecutives white spaces[0m
-Error: TAB_REPLACE_SPACE    (line:   7, col:   9):	[0mFound tab when expecting space[0m
-Error: CONSECUTIVE_NEWLINES (line:   9, col:   1):	[0mConsecutive newlines[0m
-Error: PREPROC_CONSTANT     (line:  19, col:  24):	[0mPreprocessor statement must only contain constant defines[0m
-Error: PREPROC_CONSTANT     (line:  20, col:  15):	[0mPreprocessor statement must only contain constant defines[0m
-Error: PREPROC_CONSTANT     (line:  22, col:  13):	[0mPreprocessor statement must only contain constant defines[0m
-Error: PREPROC_CONSTANT     (line:  24, col:  16):	[0mPreprocessor statement must only contain constant defines[0m
-Error: PREPROC_CONSTANT     (line:  26, col:  20):	[0mPreprocessor statement must only contain constant defines[0m
-Error: TERNARY_FBIDDEN      (line:  26, col:  20):	[0mTernaries are forbidden[0m
-Error: PREPROC_CONSTANT     (line:  27, col:  21):	[0mPreprocessor statement must only contain constant defines[0m
-Error: MACRO_FUNC_FORBIDDEN (line:  29, col:  12):	[0mMacro functions are forbidden[0m
-Error: PREPROC_CONSTANT     (line:  29, col:  16):	[0mPreprocessor statement must only contain constant defines[0m
-Error: TERNARY_FBIDDEN      (line:  29, col:  25):	[0mTernaries are forbidden[0m
-Error: MACRO_FUNC_FORBIDDEN (line:  30, col:  12):	[0mMacro functions are forbidden[0m
-Error: PREPROC_CONSTANT     (line:  30, col:  25):	[0mPreprocessor statement must only contain constant defines[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: MACRO_NAME_CAPITAL   (line:   1, col:   9):	Macro name must be capitalized
+Error: MACRO_NAME_CAPITAL   (line:   3, col:   9):	Macro name must be capitalized
+Error: CONSECUTIVE_WS       (line:   5, col:   8):	Two or more consecutives white spaces
+Error: CONSECUTIVE_WS       (line:   6, col:   8):	Two or more consecutives white spaces
+Error: TAB_REPLACE_SPACE    (line:   6, col:   8):	Found tab when expecting space
+Error: MACRO_NAME_CAPITAL   (line:   6, col:  13):	Macro name must be capitalized
+Error: CONSECUTIVE_WS       (line:   7, col:   8):	Two or more consecutives white spaces
+Error: TAB_REPLACE_SPACE    (line:   7, col:   9):	Found tab when expecting space
+Error: CONSECUTIVE_NEWLINES (line:   9, col:   1):	Consecutive newlines
+Error: PREPROC_CONSTANT     (line:  19, col:  24):	Preprocessor statement must only contain constant defines
+Error: PREPROC_CONSTANT     (line:  20, col:  15):	Preprocessor statement must only contain constant defines
+Error: PREPROC_CONSTANT     (line:  22, col:  13):	Preprocessor statement must only contain constant defines
+Error: PREPROC_CONSTANT     (line:  24, col:  16):	Preprocessor statement must only contain constant defines
+Error: PREPROC_CONSTANT     (line:  26, col:  20):	Preprocessor statement must only contain constant defines
+Error: TERNARY_FBIDDEN      (line:  26, col:  20):	Ternaries are forbidden
+Error: PREPROC_CONSTANT     (line:  27, col:  21):	Preprocessor statement must only contain constant defines
+Error: MACRO_FUNC_FORBIDDEN (line:  29, col:  12):	Macro functions are forbidden
+Error: PREPROC_CONSTANT     (line:  29, col:  16):	Preprocessor statement must only contain constant defines
+Error: TERNARY_FBIDDEN      (line:  29, col:  25):	Ternaries are forbidden
+Error: MACRO_FUNC_FORBIDDEN (line:  30, col:  12):	Macro functions are forbidden
+Error: PREPROC_CONSTANT     (line:  30, col:  25):	Preprocessor statement must only contain constant defines

--- a/tests/rules/samples/check_preprocessor_include.out
+++ b/tests/rules/samples/check_preprocessor_include.out
@@ -43,18 +43,18 @@
 [36mcheck_preprocessor_include.c[0m - [32mIsPreprocessorStatement[0m In "GlobalScope" from "None" line 22":
 		<HASH> <IDENTIFIER=include> <SPACE> <LESS_THAN> <NULL> <DOT> <IDENTIFIER=h> <MORE_THAN> <NEWLINE>
 check_preprocessor_include.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: INCLUDE_HEADER_ONLY  (line:   2, col:  10):	[0m.c file includes are forbidden[0m
-Error: INCLUDE_HEADER_ONLY  (line:   3, col:  10):	[0m.c file includes are forbidden[0m
-Error: CONSECUTIVE_NEWLINES (line:   5, col:   1):	[0mConsecutive newlines[0m
-Error: INCLUDE_START_FILE   (line:   8, col:   1):	[0mInclude must be at the start of file[0m
-Error: INCLUDE_START_FILE   (line:  11, col:   1):	[0mInclude must be at the start of file[0m
-Error: INCLUDE_START_FILE   (line:  14, col:   1):	[0mInclude must be at the start of file[0m
-Error: INCLUDE_START_FILE   (line:  15, col:   1):	[0mInclude must be at the start of file[0m
-Error: INCLUDE_START_FILE   (line:  16, col:   1):	[0mInclude must be at the start of file[0m
-Error: INCLUDE_START_FILE   (line:  17, col:   1):	[0mInclude must be at the start of file[0m
-Error: INCLUDE_START_FILE   (line:  18, col:   1):	[0mInclude must be at the start of file[0m
-Error: INCLUDE_START_FILE   (line:  19, col:   1):	[0mInclude must be at the start of file[0m
-Error: INCLUDE_START_FILE   (line:  20, col:   1):	[0mInclude must be at the start of file[0m
-Error: INCLUDE_START_FILE   (line:  21, col:   1):	[0mInclude must be at the start of file[0m
-Error: INCLUDE_START_FILE   (line:  22, col:   1):	[0mInclude must be at the start of file[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: INCLUDE_HEADER_ONLY  (line:   2, col:  10):	.c file includes are forbidden
+Error: INCLUDE_HEADER_ONLY  (line:   3, col:  10):	.c file includes are forbidden
+Error: CONSECUTIVE_NEWLINES (line:   5, col:   1):	Consecutive newlines
+Error: INCLUDE_START_FILE   (line:   8, col:   1):	Include must be at the start of file
+Error: INCLUDE_START_FILE   (line:  11, col:   1):	Include must be at the start of file
+Error: INCLUDE_START_FILE   (line:  14, col:   1):	Include must be at the start of file
+Error: INCLUDE_START_FILE   (line:  15, col:   1):	Include must be at the start of file
+Error: INCLUDE_START_FILE   (line:  16, col:   1):	Include must be at the start of file
+Error: INCLUDE_START_FILE   (line:  17, col:   1):	Include must be at the start of file
+Error: INCLUDE_START_FILE   (line:  18, col:   1):	Include must be at the start of file
+Error: INCLUDE_START_FILE   (line:  19, col:   1):	Include must be at the start of file
+Error: INCLUDE_START_FILE   (line:  20, col:   1):	Include must be at the start of file
+Error: INCLUDE_START_FILE   (line:  21, col:   1):	Include must be at the start of file
+Error: INCLUDE_START_FILE   (line:  22, col:   1):	Include must be at the start of file

--- a/tests/rules/samples/check_preprocessor_indent.out
+++ b/tests/rules/samples/check_preprocessor_indent.out
@@ -141,33 +141,33 @@ printf
 [36mcheck_preprocessor_indent.c[0m - [32mIsPreprocessorStatement[0m In "GlobalScope" from "None" line 74":
 		<HASH> <IDENTIFIER=endif> 
 check_preprocessor_indent.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: TOO_MANY_WS          (line:   1, col:   1):	[0mExtra whitespaces for indent level[0m
-Error: PREPROC_BAD_INDENT   (line:   3, col:   1):	[0mBad preprocessor indentation[0m
-Error: PREPROC_BAD_INDENT   (line:   4, col:   1):	[0mBad preprocessor indentation[0m
-Error: PREPROC_BAD_INDENT   (line:   5, col:   1):	[0mBad preprocessor indentation[0m
-Error: TOO_MANY_WS          (line:   6, col:   1):	[0mExtra whitespaces for indent level[0m
-Error: TOO_MANY_WS          (line:   7, col:   1):	[0mExtra whitespaces for indent level[0m
-Error: TAB_REPLACE_SPACE    (line:   7, col:   2):	[0mFound tab when expecting space[0m
-Error: TOO_MANY_WS          (line:   9, col:   1):	[0mExtra whitespaces for indent level[0m
-Error: MACRO_NAME_CAPITAL   (line:   9, col:  10):	[0mMacro name must be capitalized[0m
-Error: PREPROC_START_LINE   (line:  29, col:  17):	[0mPreprocessor statement not at the beginning of the line[0m
-Error: PREPROC_START_LINE   (line:  30, col:   5):	[0mPreprocessor statement not at the beginning of the line[0m
-Error: PREPROC_START_LINE   (line:  31, col:   5):	[0mPreprocessor statement not at the beginning of the line[0m
-Error: PREPROC_START_LINE   (line:  32, col:   3):	[0mPreprocessor statement not at the beginning of the line[0m
-Error: MACRO_NAME_CAPITAL   (line:  32, col:  11):	[0mMacro name must be capitalized[0m
-Error: PREPROC_NO_SPACE     (line:  34, col:   9):	[0mMissing space after preprocessor directive[0m
-Error: TAB_REPLACE_SPACE    (line:  35, col:   9):	[0mFound tab when expecting space[0m
-Error: CONSECUTIVE_WS       (line:  36, col:   9):	[94mTwo or more consecutives white spaces[0m
-Error: CONSECUTIVE_WS       (line:  37, col:   9):	[94mTwo or more consecutives white spaces[0m
-Error: TAB_REPLACE_SPACE    (line:  37, col:  11):	[0mFound tab when expecting space[0m
-Error: CONSECUTIVE_WS       (line:  38, col:   9):	[94mTwo or more consecutives white spaces[0m
-Error: TAB_REPLACE_SPACE    (line:  38, col:  10):	[0mFound tab when expecting space[0m
-Error: PREPROC_NO_SPACE     (line:  39, col:   9):	[0mMissing space after preprocessor directive[0m
-Error: TAB_REPLACE_SPACE    (line:  50, col:   8):	[0mFound tab when expecting space[0m
-Error: PREPOC_ONLY_GLOBAL   (line:  61, col:   1):	[0mPreprocessor statements are only allowed in the global scope[0m
-Error: NL_AFTER_PREPROC     (line:  62, col:   1):	[0mPreprocessor statement must be followed by a newline[0m
-Error: PREPOC_ONLY_GLOBAL   (line:  63, col:   1):	[0mPreprocessor statements are only allowed in the global scope[0m
-Error: NL_AFTER_PREPROC     (line:  64, col:   1):	[0mPreprocessor statement must be followed by a newline[0m
-Error: PREPOC_ONLY_GLOBAL   (line:  65, col:   1):	[0mPreprocessor statements are only allowed in the global scope[0m
-Error: NL_AFTER_PREPROC     (line:  66, col:   1):	[0mPreprocessor statement must be followed by a newline[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: TOO_MANY_WS          (line:   1, col:   1):	Extra whitespaces for indent level
+Error: PREPROC_BAD_INDENT   (line:   3, col:   1):	Bad preprocessor indentation
+Error: PREPROC_BAD_INDENT   (line:   4, col:   1):	Bad preprocessor indentation
+Error: PREPROC_BAD_INDENT   (line:   5, col:   1):	Bad preprocessor indentation
+Error: TOO_MANY_WS          (line:   6, col:   1):	Extra whitespaces for indent level
+Error: TOO_MANY_WS          (line:   7, col:   1):	Extra whitespaces for indent level
+Error: TAB_REPLACE_SPACE    (line:   7, col:   2):	Found tab when expecting space
+Error: TOO_MANY_WS          (line:   9, col:   1):	Extra whitespaces for indent level
+Error: MACRO_NAME_CAPITAL   (line:   9, col:  10):	Macro name must be capitalized
+Error: PREPROC_START_LINE   (line:  29, col:  17):	Preprocessor statement not at the beginning of the line
+Error: PREPROC_START_LINE   (line:  30, col:   5):	Preprocessor statement not at the beginning of the line
+Error: PREPROC_START_LINE   (line:  31, col:   5):	Preprocessor statement not at the beginning of the line
+Error: PREPROC_START_LINE   (line:  32, col:   3):	Preprocessor statement not at the beginning of the line
+Error: MACRO_NAME_CAPITAL   (line:  32, col:  11):	Macro name must be capitalized
+Error: PREPROC_NO_SPACE     (line:  34, col:   9):	Missing space after preprocessor directive
+Error: TAB_REPLACE_SPACE    (line:  35, col:   9):	Found tab when expecting space
+Error: CONSECUTIVE_WS       (line:  36, col:   9):	Two or more consecutives white spaces
+Error: CONSECUTIVE_WS       (line:  37, col:   9):	Two or more consecutives white spaces
+Error: TAB_REPLACE_SPACE    (line:  37, col:  11):	Found tab when expecting space
+Error: CONSECUTIVE_WS       (line:  38, col:   9):	Two or more consecutives white spaces
+Error: TAB_REPLACE_SPACE    (line:  38, col:  10):	Found tab when expecting space
+Error: PREPROC_NO_SPACE     (line:  39, col:   9):	Missing space after preprocessor directive
+Error: TAB_REPLACE_SPACE    (line:  50, col:   8):	Found tab when expecting space
+Error: PREPOC_ONLY_GLOBAL   (line:  61, col:   1):	Preprocessor statements are only allowed in the global scope
+Error: NL_AFTER_PREPROC     (line:  62, col:   1):	Preprocessor statement must be followed by a newline
+Error: PREPOC_ONLY_GLOBAL   (line:  63, col:   1):	Preprocessor statements are only allowed in the global scope
+Error: NL_AFTER_PREPROC     (line:  64, col:   1):	Preprocessor statement must be followed by a newline
+Error: PREPOC_ONLY_GLOBAL   (line:  65, col:   1):	Preprocessor statements are only allowed in the global scope
+Error: NL_AFTER_PREPROC     (line:  66, col:   1):	Preprocessor statement must be followed by a newline

--- a/tests/rules/samples/check_preprocessor_indent_2.out
+++ b/tests/rules/samples/check_preprocessor_indent_2.out
@@ -31,16 +31,16 @@
 [36mcheck_preprocessor_indent_2.c[0m - [32mIsPreprocessorStatement[0m In "GlobalScope" from "None" line 16":
 		<HASH> <IDENTIFIER=endif> <NEWLINE>
 check_preprocessor_indent_2.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: PREPROC_BAD_ENDIF    (line:   1, col:   1):	[0mEndif preprocessor statement without if, elif or else[0m
-Error: PREPROC_BAD_ELSE     (line:   2, col:   1):	[0mElse preprocessor statement without if or elif[0m
-Error: PREPROC_BAD_ENDIF    (line:   3, col:   1):	[0mEndif preprocessor statement without if, elif or else[0m
-Error: PREPROC_BAD_ELSE     (line:   4, col:   1):	[0mElse preprocessor statement without if or elif[0m
-Error: PREPROC_BAD_ENDIF    (line:   5, col:   1):	[0mEndif preprocessor statement without if, elif or else[0m
-Error: PREPROC_BAD_ENDIF    (line:   6, col:   1):	[0mEndif preprocessor statement without if, elif or else[0m
-Error: PREPROC_BAD_ENDIF    (line:   7, col:   1):	[0mEndif preprocessor statement without if, elif or else[0m
-Error: PREPROC_BAD_ELSE     (line:   8, col:   1):	[0mElse preprocessor statement without if or elif[0m
-Error: PREPROC_BAD_ELSE     (line:   9, col:   1):	[0mElse preprocessor statement without if or elif[0m
-Error: PREPROC_BAD_ENDIF    (line:  10, col:   1):	[0mEndif preprocessor statement without if, elif or else[0m
-Error: PREPROC_BAD_ELSE     (line:  15, col:   1):	[0mElse preprocessor statement without if or elif[0m
-Error: PREPROC_BAD_ENDIF    (line:  16, col:   1):	[0mEndif preprocessor statement without if, elif or else[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: PREPROC_BAD_ENDIF    (line:   1, col:   1):	Endif preprocessor statement without if, elif or else
+Error: PREPROC_BAD_ELSE     (line:   2, col:   1):	Else preprocessor statement without if or elif
+Error: PREPROC_BAD_ENDIF    (line:   3, col:   1):	Endif preprocessor statement without if, elif or else
+Error: PREPROC_BAD_ELSE     (line:   4, col:   1):	Else preprocessor statement without if or elif
+Error: PREPROC_BAD_ENDIF    (line:   5, col:   1):	Endif preprocessor statement without if, elif or else
+Error: PREPROC_BAD_ENDIF    (line:   6, col:   1):	Endif preprocessor statement without if, elif or else
+Error: PREPROC_BAD_ENDIF    (line:   7, col:   1):	Endif preprocessor statement without if, elif or else
+Error: PREPROC_BAD_ELSE     (line:   8, col:   1):	Else preprocessor statement without if or elif
+Error: PREPROC_BAD_ELSE     (line:   9, col:   1):	Else preprocessor statement without if or elif
+Error: PREPROC_BAD_ENDIF    (line:  10, col:   1):	Endif preprocessor statement without if, elif or else
+Error: PREPROC_BAD_ELSE     (line:  15, col:   1):	Else preprocessor statement without if or elif
+Error: PREPROC_BAD_ENDIF    (line:  16, col:   1):	Endif preprocessor statement without if, elif or else

--- a/tests/rules/samples/check_preprocessor_protection.out
+++ b/tests/rules/samples/check_preprocessor_protection.out
@@ -31,9 +31,9 @@
 [36mcheck_preprocessor_protection.h[0m - [32mIsPreprocessorStatement[0m In "GlobalScope" from "None" line 16":
 		<HASH> <IDENTIFIER=endif> <NEWLINE>
 check_preprocessor_protection.h: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: HEADER_PROT_ALL      (line:   3, col:   1):	[0mHeader protection must include all the instructions[0m
-Error: HEADER_PROT_UPPER    (line:   3, col:   9):	[0mHeader protection must be in uppercase[0m
-Error: HEADER_PROT_ALL_AF   (line:   8, col:   1):	[0mInstructions after header protection are forbidden[0m
-Error: HEADER_PROT_MULT     (line:  10, col:   1):	[0mMultiple header protections, only one is allowed[0m
-Error: HEADER_PROT_MULT     (line:  14, col:   1):	[0mMultiple header protections, only one is allowed[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: HEADER_PROT_ALL      (line:   3, col:   1):	Header protection must include all the instructions
+Error: HEADER_PROT_UPPER    (line:   3, col:   9):	Header protection must be in uppercase
+Error: HEADER_PROT_ALL_AF   (line:   8, col:   1):	Instructions after header protection are forbidden
+Error: HEADER_PROT_MULT     (line:  10, col:   1):	Multiple header protections, only one is allowed
+Error: HEADER_PROT_MULT     (line:  14, col:   1):	Multiple header protections, only one is allowed

--- a/tests/rules/samples/check_preprocessor_protection_2.out
+++ b/tests/rules/samples/check_preprocessor_protection_2.out
@@ -9,4 +9,4 @@
 [36mcheck_preprocessor_protection_2.h[0m - [32mIsPreprocessorStatement[0m In "GlobalScope" from "None" line 5":
 		<HASH> <IDENTIFIER=endif> <NEWLINE>
 check_preprocessor_protection_2.h: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header

--- a/tests/rules/samples/check_preprocessor_protection_3.out
+++ b/tests/rules/samples/check_preprocessor_protection_3.out
@@ -11,6 +11,6 @@
 [36mcheck_preprocessor_protection_3.h[0m - [32mIsPreprocessorStatement[0m In "GlobalScope" from "None" line 6":
 		<HASH> <IDENTIFIER=define> <SPACE> <IDENTIFIER=CHECK_PREPROCESSOR_PROTECTION_3_H> <NEWLINE>
 check_preprocessor_protection_3.h: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: HEADER_PROT_NODEF    (line:   3, col:   1):	[0mHeader protection not containing #define[0m
-Error: HEADER_PROT_ALL_AF   (line:   6, col:   1):	[0mInstructions after header protection are forbidden[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: HEADER_PROT_NODEF    (line:   3, col:   1):	Header protection not containing #define
+Error: HEADER_PROT_ALL_AF   (line:   6, col:   1):	Instructions after header protection are forbidden

--- a/tests/rules/samples/check_utype_declaration_1.out
+++ b/tests/rules/samples/check_utype_declaration_1.out
@@ -69,13 +69,13 @@
 [36mcheck_utype_declaration_1.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 34":
 		<RBRACE> <NEWLINE>
 check_utype_declaration_1.c: Error!
-Error: FORBIDDEN_STRUCT     (line:   1, col:   1):	[0mStruct declaration are not allowed in .c files[0m
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: FORBIDDEN_STRUCT     (line:   8, col:   5):	[0mStruct declaration are not allowed in .c files[0m
-Error: TYPE_NOT_GLOBAL      (line:   8, col:   5):	[0mEnums, structs and unions need to be defined only in global scope[0m
-Error: FORBIDDEN_ENUM       (line:  15, col:   1):	[0mEnum declaration are not allowed in .c files[0m
-Error: FORBIDDEN_UNION      (line:  23, col:   5):	[0mUnion declaration are not allowed in .c files[0m
-Error: TYPE_NOT_GLOBAL      (line:  23, col:   5):	[0mEnums, structs and unions need to be defined only in global scope[0m
-Error: WRONG_SCOPE_COMMENT  (line:  27, col:  18):	[95mComment is invalid in this scope[0m
-Error: WRONG_SCOPE_COMMENT  (line:  27, col:  18):	[95mComment is invalid in this scope[0m
-Error: WRONG_SCOPE_COMMENT  (line:  28, col:   1):	[95mComment is invalid in this scope[0m
+Error: FORBIDDEN_STRUCT     (line:   1, col:   1):	Struct declaration are not allowed in .c files
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: FORBIDDEN_STRUCT     (line:   8, col:   5):	Struct declaration are not allowed in .c files
+Error: TYPE_NOT_GLOBAL      (line:   8, col:   5):	Enums, structs and unions need to be defined only in global scope
+Error: FORBIDDEN_ENUM       (line:  15, col:   1):	Enum declaration are not allowed in .c files
+Error: FORBIDDEN_UNION      (line:  23, col:   5):	Union declaration are not allowed in .c files
+Error: TYPE_NOT_GLOBAL      (line:  23, col:   5):	Enums, structs and unions need to be defined only in global scope
+Error: WRONG_SCOPE_COMMENT  (line:  27, col:  18):	Comment is invalid in this scope
+Error: WRONG_SCOPE_COMMENT  (line:  27, col:  18):	Comment is invalid in this scope
+Error: WRONG_SCOPE_COMMENT  (line:  28, col:   1):	Comment is invalid in this scope

--- a/tests/rules/samples/check_utype_declaration_2.out
+++ b/tests/rules/samples/check_utype_declaration_2.out
@@ -23,4 +23,4 @@
 [36mcheck_utype_declaration_2.h[0m - [32mIsBlockEnd[0m In "UserDefinedType" from "GlobalScope" line 12":
 		<RBRACE> <SEMI_COLON> <NEWLINE>
 check_utype_declaration_2.h: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header

--- a/tests/rules/samples/glued_operators.out
+++ b/tests/rules/samples/glued_operators.out
@@ -41,4 +41,4 @@
 [36mglued_operators.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 21":
 		<RBRACE> <NEWLINE>
 glued_operators.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header

--- a/tests/rules/samples/integer_constants.out
+++ b/tests/rules/samples/integer_constants.out
@@ -79,53 +79,53 @@
 [36minteger_constants.c[0m - [32mIsEmptyLine[0m In "GlobalScope" from "None" line 40":
 		<NEWLINE>
 integer_constants.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: DECL_ASSIGN_LINE     (line:   3, col:  33):	[0mDeclaration and assignation on a single line[0m
-Error: DECL_ASSIGN_LINE     (line:   4, col:  34):	[0mDeclaration and assignation on a single line[0m
-Error: DECL_ASSIGN_LINE     (line:   5, col:  34):	[0mDeclaration and assignation on a single line[0m
-Error: DECL_ASSIGN_LINE     (line:   6, col:  35):	[0mDeclaration and assignation on a single line[0m
-Error: DECL_ASSIGN_LINE     (line:   7, col:  35):	[0mDeclaration and assignation on a single line[0m
-Error: TOO_MANY_VARS_FUNC   (line:   8, col:   1):	[91mToo many variables declarations in a function[0m
-Error: DECL_ASSIGN_LINE     (line:   8, col:  36):	[0mDeclaration and assignation on a single line[0m
-Error: TOO_MANY_VARS_FUNC   (line:   9, col:   1):	[91mToo many variables declarations in a function[0m
-Error: DECL_ASSIGN_LINE     (line:   9, col:  33):	[0mDeclaration and assignation on a single line[0m
-Error: TOO_MANY_VARS_FUNC   (line:  10, col:   1):	[91mToo many variables declarations in a function[0m
-Error: DECL_ASSIGN_LINE     (line:  10, col:  34):	[0mDeclaration and assignation on a single line[0m
-Error: TOO_MANY_VARS_FUNC   (line:  11, col:   1):	[91mToo many variables declarations in a function[0m
-Error: DECL_ASSIGN_LINE     (line:  11, col:  33):	[0mDeclaration and assignation on a single line[0m
-Error: TOO_MANY_VARS_FUNC   (line:  12, col:   1):	[91mToo many variables declarations in a function[0m
-Error: DECL_ASSIGN_LINE     (line:  12, col:  34):	[0mDeclaration and assignation on a single line[0m
-Error: TOO_MANY_VARS_FUNC   (line:  13, col:   1):	[91mToo many variables declarations in a function[0m
-Error: DECL_ASSIGN_LINE     (line:  13, col:  34):	[0mDeclaration and assignation on a single line[0m
-Error: TOO_MANY_VARS_FUNC   (line:  14, col:   1):	[91mToo many variables declarations in a function[0m
-Error: DECL_ASSIGN_LINE     (line:  14, col:  35):	[0mDeclaration and assignation on a single line[0m
-Error: TOO_MANY_VARS_FUNC   (line:  15, col:   1):	[91mToo many variables declarations in a function[0m
-Error: DECL_ASSIGN_LINE     (line:  15, col:  35):	[0mDeclaration and assignation on a single line[0m
-Error: TOO_MANY_VARS_FUNC   (line:  16, col:   1):	[91mToo many variables declarations in a function[0m
-Error: DECL_ASSIGN_LINE     (line:  16, col:  36):	[0mDeclaration and assignation on a single line[0m
-Error: TOO_MANY_VARS_FUNC   (line:  17, col:   1):	[91mToo many variables declarations in a function[0m
-Error: DECL_ASSIGN_LINE     (line:  17, col:  33):	[0mDeclaration and assignation on a single line[0m
-Error: TOO_MANY_VARS_FUNC   (line:  18, col:   1):	[91mToo many variables declarations in a function[0m
-Error: DECL_ASSIGN_LINE     (line:  18, col:  34):	[0mDeclaration and assignation on a single line[0m
-Error: TOO_MANY_VARS_FUNC   (line:  19, col:   1):	[91mToo many variables declarations in a function[0m
-Error: DECL_ASSIGN_LINE     (line:  19, col:  33):	[0mDeclaration and assignation on a single line[0m
-Error: TOO_MANY_VARS_FUNC   (line:  20, col:   1):	[91mToo many variables declarations in a function[0m
-Error: DECL_ASSIGN_LINE     (line:  20, col:  34):	[0mDeclaration and assignation on a single line[0m
-Error: TOO_MANY_VARS_FUNC   (line:  21, col:   1):	[91mToo many variables declarations in a function[0m
-Error: DECL_ASSIGN_LINE     (line:  21, col:  34):	[0mDeclaration and assignation on a single line[0m
-Error: TOO_MANY_VARS_FUNC   (line:  22, col:   1):	[91mToo many variables declarations in a function[0m
-Error: DECL_ASSIGN_LINE     (line:  22, col:  35):	[0mDeclaration and assignation on a single line[0m
-Error: TOO_MANY_VARS_FUNC   (line:  23, col:   1):	[91mToo many variables declarations in a function[0m
-Error: DECL_ASSIGN_LINE     (line:  23, col:  35):	[0mDeclaration and assignation on a single line[0m
-Error: TOO_MANY_VARS_FUNC   (line:  24, col:   1):	[91mToo many variables declarations in a function[0m
-Error: DECL_ASSIGN_LINE     (line:  24, col:  36):	[0mDeclaration and assignation on a single line[0m
-Error: TOO_MANY_VARS_FUNC   (line:  25, col:   1):	[91mToo many variables declarations in a function[0m
-Error: DECL_ASSIGN_LINE     (line:  25, col:  33):	[0mDeclaration and assignation on a single line[0m
-Error: TOO_MANY_VARS_FUNC   (line:  26, col:   1):	[91mToo many variables declarations in a function[0m
-Error: DECL_ASSIGN_LINE     (line:  26, col:  34):	[0mDeclaration and assignation on a single line[0m
-Error: LINE_TOO_LONG        (line:  29, col:  82):	[94mline too long[0m
-Error: TOO_MANY_ARGS        (line:  29, col: 115):	[91mFunction has more than 4 arguments[0m
-Error: TOO_MANY_VARS_FUNC   (line:  36, col:   1):	[91mToo many variables declarations in a function[0m
-Error: TOO_MANY_VARS_FUNC   (line:  37, col:   1):	[91mToo many variables declarations in a function[0m
-Error: TOO_MANY_VARS_FUNC   (line:  38, col:   1):	[91mToo many variables declarations in a function[0m
-Error: EMPTY_LINE_EOF       (line:  40, col:   1):	[0mEmpty line at end of file[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: DECL_ASSIGN_LINE     (line:   3, col:  33):	Declaration and assignation on a single line
+Error: DECL_ASSIGN_LINE     (line:   4, col:  34):	Declaration and assignation on a single line
+Error: DECL_ASSIGN_LINE     (line:   5, col:  34):	Declaration and assignation on a single line
+Error: DECL_ASSIGN_LINE     (line:   6, col:  35):	Declaration and assignation on a single line
+Error: DECL_ASSIGN_LINE     (line:   7, col:  35):	Declaration and assignation on a single line
+Error: TOO_MANY_VARS_FUNC   (line:   8, col:   1):	Too many variables declarations in a function
+Error: DECL_ASSIGN_LINE     (line:   8, col:  36):	Declaration and assignation on a single line
+Error: TOO_MANY_VARS_FUNC   (line:   9, col:   1):	Too many variables declarations in a function
+Error: DECL_ASSIGN_LINE     (line:   9, col:  33):	Declaration and assignation on a single line
+Error: TOO_MANY_VARS_FUNC   (line:  10, col:   1):	Too many variables declarations in a function
+Error: DECL_ASSIGN_LINE     (line:  10, col:  34):	Declaration and assignation on a single line
+Error: TOO_MANY_VARS_FUNC   (line:  11, col:   1):	Too many variables declarations in a function
+Error: DECL_ASSIGN_LINE     (line:  11, col:  33):	Declaration and assignation on a single line
+Error: TOO_MANY_VARS_FUNC   (line:  12, col:   1):	Too many variables declarations in a function
+Error: DECL_ASSIGN_LINE     (line:  12, col:  34):	Declaration and assignation on a single line
+Error: TOO_MANY_VARS_FUNC   (line:  13, col:   1):	Too many variables declarations in a function
+Error: DECL_ASSIGN_LINE     (line:  13, col:  34):	Declaration and assignation on a single line
+Error: TOO_MANY_VARS_FUNC   (line:  14, col:   1):	Too many variables declarations in a function
+Error: DECL_ASSIGN_LINE     (line:  14, col:  35):	Declaration and assignation on a single line
+Error: TOO_MANY_VARS_FUNC   (line:  15, col:   1):	Too many variables declarations in a function
+Error: DECL_ASSIGN_LINE     (line:  15, col:  35):	Declaration and assignation on a single line
+Error: TOO_MANY_VARS_FUNC   (line:  16, col:   1):	Too many variables declarations in a function
+Error: DECL_ASSIGN_LINE     (line:  16, col:  36):	Declaration and assignation on a single line
+Error: TOO_MANY_VARS_FUNC   (line:  17, col:   1):	Too many variables declarations in a function
+Error: DECL_ASSIGN_LINE     (line:  17, col:  33):	Declaration and assignation on a single line
+Error: TOO_MANY_VARS_FUNC   (line:  18, col:   1):	Too many variables declarations in a function
+Error: DECL_ASSIGN_LINE     (line:  18, col:  34):	Declaration and assignation on a single line
+Error: TOO_MANY_VARS_FUNC   (line:  19, col:   1):	Too many variables declarations in a function
+Error: DECL_ASSIGN_LINE     (line:  19, col:  33):	Declaration and assignation on a single line
+Error: TOO_MANY_VARS_FUNC   (line:  20, col:   1):	Too many variables declarations in a function
+Error: DECL_ASSIGN_LINE     (line:  20, col:  34):	Declaration and assignation on a single line
+Error: TOO_MANY_VARS_FUNC   (line:  21, col:   1):	Too many variables declarations in a function
+Error: DECL_ASSIGN_LINE     (line:  21, col:  34):	Declaration and assignation on a single line
+Error: TOO_MANY_VARS_FUNC   (line:  22, col:   1):	Too many variables declarations in a function
+Error: DECL_ASSIGN_LINE     (line:  22, col:  35):	Declaration and assignation on a single line
+Error: TOO_MANY_VARS_FUNC   (line:  23, col:   1):	Too many variables declarations in a function
+Error: DECL_ASSIGN_LINE     (line:  23, col:  35):	Declaration and assignation on a single line
+Error: TOO_MANY_VARS_FUNC   (line:  24, col:   1):	Too many variables declarations in a function
+Error: DECL_ASSIGN_LINE     (line:  24, col:  36):	Declaration and assignation on a single line
+Error: TOO_MANY_VARS_FUNC   (line:  25, col:   1):	Too many variables declarations in a function
+Error: DECL_ASSIGN_LINE     (line:  25, col:  33):	Declaration and assignation on a single line
+Error: TOO_MANY_VARS_FUNC   (line:  26, col:   1):	Too many variables declarations in a function
+Error: DECL_ASSIGN_LINE     (line:  26, col:  34):	Declaration and assignation on a single line
+Error: LINE_TOO_LONG        (line:  29, col:  82):	line too long
+Error: TOO_MANY_ARGS        (line:  29, col: 115):	Function has more than 4 arguments
+Error: TOO_MANY_VARS_FUNC   (line:  36, col:   1):	Too many variables declarations in a function
+Error: TOO_MANY_VARS_FUNC   (line:  37, col:   1):	Too many variables declarations in a function
+Error: TOO_MANY_VARS_FUNC   (line:  38, col:   1):	Too many variables declarations in a function
+Error: EMPTY_LINE_EOF       (line:  40, col:   1):	Empty line at end of file

--- a/tests/rules/samples/ko_func_name.out
+++ b/tests/rules/samples/ko_func_name.out
@@ -5,4 +5,4 @@
 [36mko_func_name.c[0m - [32mIsFuncPrototype[0m In "GlobalScope" from "None" line 3":
 		<INT> <TAB> <IDENTIFIER=B> <LPARENTHESIS> <VOID> <RPARENTHESIS> <SEMI_COLON> <NEWLINE>
 ko_func_name.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header

--- a/tests/rules/samples/ko_func_name2.out
+++ b/tests/rules/samples/ko_func_name2.out
@@ -41,15 +41,15 @@
 [36mko_func_name2.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 21":
 		<RBRACE> <NEWLINE>
 ko_func_name2.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: EXP_PARENTHESIS      (line:   1, col:   9):	[94mExpected parenthesis[0m
-Error: EXP_PARENTHESIS      (line:   6, col:   9):	[94mExpected parenthesis[0m
-Error: SPACE_BEFORE_FUNC    (line:  11, col:   4):	[94mspace before function name[0m
-Error: EXP_PARENTHESIS      (line:  11, col:   9):	[94mExpected parenthesis[0m
-Error: TOO_FEW_TAB          (line:  13, col:   1):	[0mMissing tabs for indent level[0m
-Error: SPACE_REPLACE_TAB    (line:  13, col:   5):	[0mFound space when expecting tab[0m
-Error: SPACE_REPLACE_TAB    (line:  13, col:   8):	[0mFound space when expecting tab[0m
-Error: DECL_ASSIGN_LINE     (line:  13, col:  17):	[0mDeclaration and assignation on a single line[0m
-Error: TOO_FEW_TAB          (line:  15, col:   1):	[0mMissing tabs for indent level[0m
-Error: SPACE_REPLACE_TAB    (line:  15, col:   5):	[0mFound space when expecting tab[0m
-Error: SPACE_BEFORE_FUNC    (line:  18, col:  11):	[94mspace before function name[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: EXP_PARENTHESIS      (line:   1, col:   9):	Expected parenthesis
+Error: EXP_PARENTHESIS      (line:   6, col:   9):	Expected parenthesis
+Error: SPACE_BEFORE_FUNC    (line:  11, col:   4):	space before function name
+Error: EXP_PARENTHESIS      (line:  11, col:   9):	Expected parenthesis
+Error: TOO_FEW_TAB          (line:  13, col:   1):	Missing tabs for indent level
+Error: SPACE_REPLACE_TAB    (line:  13, col:   5):	Found space when expecting tab
+Error: SPACE_REPLACE_TAB    (line:  13, col:   8):	Found space when expecting tab
+Error: DECL_ASSIGN_LINE     (line:  13, col:  17):	Declaration and assignation on a single line
+Error: TOO_FEW_TAB          (line:  15, col:   1):	Missing tabs for indent level
+Error: SPACE_REPLACE_TAB    (line:  15, col:   5):	Found space when expecting tab
+Error: SPACE_BEFORE_FUNC    (line:  18, col:  11):	space before function name

--- a/tests/rules/samples/ko_include.out
+++ b/tests/rules/samples/ko_include.out
@@ -5,7 +5,7 @@
 [36mko_include.c[0m - [32mIsPreprocessorStatement[0m In "GlobalScope" from "None" line 3":
 		<HASH> <IDENTIFIER=include> <SPACE> <LESS_THAN> <IDENTIFIER=main> <DOT> <IDENTIFIER=c> <MORE_THAN> <NEWLINE>
 ko_include.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: INCLUDE_HEADER_ONLY  (line:   1, col:  10):	[0m.c file includes are forbidden[0m
-Error: MACRO_NAME_CAPITAL   (line:   2, col:   9):	[0mMacro name must be capitalized[0m
-Error: INCLUDE_HEADER_ONLY  (line:   3, col:  10):	[0m.c file includes are forbidden[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: INCLUDE_HEADER_ONLY  (line:   1, col:  10):	.c file includes are forbidden
+Error: MACRO_NAME_CAPITAL   (line:   2, col:   9):	Macro name must be capitalized
+Error: INCLUDE_HEADER_ONLY  (line:   3, col:  10):	.c file includes are forbidden

--- a/tests/rules/samples/ko_include2.out
+++ b/tests/rules/samples/ko_include2.out
@@ -11,12 +11,12 @@
 [36mko_include2.c[0m - [32mIsPreprocessorStatement[0m In "GlobalScope" from "None" line 6":
 		<HASH> <IDENTIFIER=include> <TAB> <TAB> <LESS_THAN> <IDENTIFIER=unistd> <DOT> <IDENTIFIER=h> <MORE_THAN> <NEWLINE>
 ko_include2.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: PREPROC_NO_SPACE     (line:   1, col:   9):	[0mMissing space after preprocessor directive[0m
-Error: TAB_REPLACE_SPACE    (line:   2, col:   9):	[0mFound tab when expecting space[0m
-Error: CONSECUTIVE_WS       (line:   3, col:   9):	[94mTwo or more consecutives white spaces[0m
-Error: TAB_REPLACE_SPACE    (line:   3, col:   9):	[0mFound tab when expecting space[0m
-Error: PREPROC_NO_SPACE     (line:   4, col:   9):	[0mMissing space after preprocessor directive[0m
-Error: TAB_REPLACE_SPACE    (line:   5, col:   9):	[0mFound tab when expecting space[0m
-Error: CONSECUTIVE_WS       (line:   6, col:   9):	[94mTwo or more consecutives white spaces[0m
-Error: TAB_REPLACE_SPACE    (line:   6, col:   9):	[0mFound tab when expecting space[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: PREPROC_NO_SPACE     (line:   1, col:   9):	Missing space after preprocessor directive
+Error: TAB_REPLACE_SPACE    (line:   2, col:   9):	Found tab when expecting space
+Error: CONSECUTIVE_WS       (line:   3, col:   9):	Two or more consecutives white spaces
+Error: TAB_REPLACE_SPACE    (line:   3, col:   9):	Found tab when expecting space
+Error: PREPROC_NO_SPACE     (line:   4, col:   9):	Missing space after preprocessor directive
+Error: TAB_REPLACE_SPACE    (line:   5, col:   9):	Found tab when expecting space
+Error: CONSECUTIVE_WS       (line:   6, col:   9):	Two or more consecutives white spaces
+Error: TAB_REPLACE_SPACE    (line:   6, col:   9):	Found tab when expecting space

--- a/tests/rules/samples/ko_pointer1.out
+++ b/tests/rules/samples/ko_pointer1.out
@@ -63,38 +63,38 @@
 [36mko_pointer1.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 23":
 		<RBRACE> 
 ko_pointer1.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: BRACE_NEWLINE        (line:   1, col:  16):	[93mExpected newline before brace[0m
-Error: SPC_AFTER_POINTER    (line:   2, col:  11):	[94mspace after pointer[0m
-Error: SPC_AFTER_POINTER    (line:   2, col:  12):	[94mspace after pointer[0m
-Error: BRACE_NEWLINE        (line:   5, col:  16):	[93mExpected newline before brace[0m
-Error: SPC_AFTER_POINTER    (line:   6, col:  11):	[94mspace after pointer[0m
-Error: SPC_AFTER_POINTER    (line:   6, col:  13):	[94mspace after pointer[0m
-Error: NL_AFTER_VAR_DECL    (line:   7, col:  21):	[0mVariable declarations must be followed by a newline[0m
-Error: TOO_FEW_TAB          (line:   7, col:  21):	[0mMissing tabs for indent level[0m
-Error: TOO_MANY_INSTR       (line:   7, col:  21):	[0mToo many instructions on a single line[0m
-Error: NO_SPC_AFR_PAR       (line:   7, col:  38):	[94mExtra space after parenthesis (brace/bracket)[0m
-Error: NO_SPC_AFR_PAR       (line:   7, col:  40):	[94mExtra space after parenthesis (brace/bracket)[0m
-Error: NO_SPC_BFR_PAR       (line:   7, col:  40):	[94mExtra space before parenthesis (brace/bracket)[0m
-Error: NO_SPC_AFR_PAR       (line:   7, col:  42):	[94mExtra space after parenthesis (brace/bracket)[0m
-Error: NO_SPC_BFR_PAR       (line:   7, col:  42):	[94mExtra space before parenthesis (brace/bracket)[0m
-Error: NO_SPC_BFR_PAR       (line:   7, col:  44):	[94mExtra space before parenthesis (brace/bracket)[0m
-Error: BRACE_NEWLINE        (line:  10, col:  16):	[93mExpected newline before brace[0m
-Error: SPC_AFTER_POINTER    (line:  11, col:  11):	[94mspace after pointer[0m
-Error: SPC_AFTER_POINTER    (line:  11, col:  13):	[94mspace after pointer[0m
-Error: NL_AFTER_VAR_DECL    (line:  12, col:  21):	[0mVariable declarations must be followed by a newline[0m
-Error: TOO_FEW_TAB          (line:  12, col:  21):	[0mMissing tabs for indent level[0m
-Error: TOO_MANY_INSTR       (line:  12, col:  21):	[0mToo many instructions on a single line[0m
-Error: BRACE_NEWLINE        (line:  15, col:  16):	[93mExpected newline before brace[0m
-Error: SPC_AFTER_POINTER    (line:  16, col:  11):	[94mspace after pointer[0m
-Error: SPC_AFTER_POINTER    (line:  16, col:  13):	[94mspace after pointer[0m
-Error: NL_AFTER_VAR_DECL    (line:  17, col:  21):	[0mVariable declarations must be followed by a newline[0m
-Error: TOO_FEW_TAB          (line:  17, col:  21):	[0mMissing tabs for indent level[0m
-Error: TOO_MANY_INSTR       (line:  17, col:  21):	[0mToo many instructions on a single line[0m
-Error: BRACE_NEWLINE        (line:  20, col:  16):	[93mExpected newline before brace[0m
-Error: SPC_AFTER_POINTER    (line:  21, col:  11):	[94mspace after pointer[0m
-Error: SPC_AFTER_POINTER    (line:  21, col:  13):	[94mspace after pointer[0m
-Error: NL_AFTER_VAR_DECL    (line:  22, col:  21):	[0mVariable declarations must be followed by a newline[0m
-Error: TOO_FEW_TAB          (line:  22, col:  21):	[0mMissing tabs for indent level[0m
-Error: TOO_MANY_INSTR       (line:  22, col:  21):	[0mToo many instructions on a single line[0m
-Error: BRACE_SHOULD_EOL     (line:  23, col:   1):	[0mExpected newline after brace[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: BRACE_NEWLINE        (line:   1, col:  16):	Expected newline before brace
+Error: SPC_AFTER_POINTER    (line:   2, col:  11):	space after pointer
+Error: SPC_AFTER_POINTER    (line:   2, col:  12):	space after pointer
+Error: BRACE_NEWLINE        (line:   5, col:  16):	Expected newline before brace
+Error: SPC_AFTER_POINTER    (line:   6, col:  11):	space after pointer
+Error: SPC_AFTER_POINTER    (line:   6, col:  13):	space after pointer
+Error: NL_AFTER_VAR_DECL    (line:   7, col:  21):	Variable declarations must be followed by a newline
+Error: TOO_FEW_TAB          (line:   7, col:  21):	Missing tabs for indent level
+Error: TOO_MANY_INSTR       (line:   7, col:  21):	Too many instructions on a single line
+Error: NO_SPC_AFR_PAR       (line:   7, col:  38):	Extra space after parenthesis (brace/bracket)
+Error: NO_SPC_AFR_PAR       (line:   7, col:  40):	Extra space after parenthesis (brace/bracket)
+Error: NO_SPC_BFR_PAR       (line:   7, col:  40):	Extra space before parenthesis (brace/bracket)
+Error: NO_SPC_AFR_PAR       (line:   7, col:  42):	Extra space after parenthesis (brace/bracket)
+Error: NO_SPC_BFR_PAR       (line:   7, col:  42):	Extra space before parenthesis (brace/bracket)
+Error: NO_SPC_BFR_PAR       (line:   7, col:  44):	Extra space before parenthesis (brace/bracket)
+Error: BRACE_NEWLINE        (line:  10, col:  16):	Expected newline before brace
+Error: SPC_AFTER_POINTER    (line:  11, col:  11):	space after pointer
+Error: SPC_AFTER_POINTER    (line:  11, col:  13):	space after pointer
+Error: NL_AFTER_VAR_DECL    (line:  12, col:  21):	Variable declarations must be followed by a newline
+Error: TOO_FEW_TAB          (line:  12, col:  21):	Missing tabs for indent level
+Error: TOO_MANY_INSTR       (line:  12, col:  21):	Too many instructions on a single line
+Error: BRACE_NEWLINE        (line:  15, col:  16):	Expected newline before brace
+Error: SPC_AFTER_POINTER    (line:  16, col:  11):	space after pointer
+Error: SPC_AFTER_POINTER    (line:  16, col:  13):	space after pointer
+Error: NL_AFTER_VAR_DECL    (line:  17, col:  21):	Variable declarations must be followed by a newline
+Error: TOO_FEW_TAB          (line:  17, col:  21):	Missing tabs for indent level
+Error: TOO_MANY_INSTR       (line:  17, col:  21):	Too many instructions on a single line
+Error: BRACE_NEWLINE        (line:  20, col:  16):	Expected newline before brace
+Error: SPC_AFTER_POINTER    (line:  21, col:  11):	space after pointer
+Error: SPC_AFTER_POINTER    (line:  21, col:  13):	space after pointer
+Error: NL_AFTER_VAR_DECL    (line:  22, col:  21):	Variable declarations must be followed by a newline
+Error: TOO_FEW_TAB          (line:  22, col:  21):	Missing tabs for indent level
+Error: TOO_MANY_INSTR       (line:  22, col:  21):	Too many instructions on a single line
+Error: BRACE_SHOULD_EOL     (line:  23, col:   1):	Expected newline after brace

--- a/tests/rules/samples/ko_pointer2.out
+++ b/tests/rules/samples/ko_pointer2.out
@@ -93,54 +93,54 @@
 [36mko_pointer2.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 37":
 		<RBRACE> <NEWLINE>
 ko_pointer2.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: BRACE_NEWLINE        (line:   1, col:  16):	[93mExpected newline before brace[0m
-Error: SPC_AFTER_POINTER    (line:   2, col:  11):	[94mspace after pointer[0m
-Error: SPC_AFTER_POINTER    (line:   2, col:  13):	[94mspace after pointer[0m
-Error: NL_AFTER_VAR_DECL    (line:   3, col:  21):	[0mVariable declarations must be followed by a newline[0m
-Error: TOO_FEW_TAB          (line:   3, col:  21):	[0mMissing tabs for indent level[0m
-Error: TOO_MANY_INSTR       (line:   3, col:  21):	[0mToo many instructions on a single line[0m
-Error: BRACE_NEWLINE        (line:   6, col:  16):	[93mExpected newline before brace[0m
-Error: SPC_AFTER_POINTER    (line:   7, col:  11):	[94mspace after pointer[0m
-Error: SPC_AFTER_POINTER    (line:   7, col:  13):	[94mspace after pointer[0m
-Error: NL_AFTER_VAR_DECL    (line:   8, col:  21):	[0mVariable declarations must be followed by a newline[0m
-Error: TOO_FEW_TAB          (line:   8, col:  21):	[0mMissing tabs for indent level[0m
-Error: TOO_MANY_INSTR       (line:   8, col:  21):	[0mToo many instructions on a single line[0m
-Error: MIXED_SPACE_TAB      (line:   8, col:  23):	[93mMixed spaces and tabs[0m
-Error: TAB_INSTEAD_SPC      (line:   8, col:  24):	[94mFound tab when expecting space[0m
-Error: MIXED_SPACE_TAB      (line:  10, col:  12):	[93mMixed spaces and tabs[0m
-Error: TAB_INSTEAD_SPC      (line:  10, col:  13):	[94mFound tab when expecting space[0m
-Error: BRACE_NEWLINE        (line:  16, col:  16):	[93mExpected newline before brace[0m
-Error: SPC_AFTER_POINTER    (line:  17, col:  11):	[94mspace after pointer[0m
-Error: SPC_AFTER_POINTER    (line:  17, col:  13):	[94mspace after pointer[0m
-Error: NL_AFTER_VAR_DECL    (line:  18, col:  21):	[0mVariable declarations must be followed by a newline[0m
-Error: TOO_FEW_TAB          (line:  18, col:  21):	[0mMissing tabs for indent level[0m
-Error: TOO_MANY_INSTR       (line:  18, col:  21):	[0mToo many instructions on a single line[0m
-Error: MIXED_SPACE_TAB      (line:  18, col:  23):	[93mMixed spaces and tabs[0m
-Error: TAB_INSTEAD_SPC      (line:  18, col:  24):	[94mFound tab when expecting space[0m
-Error: MIXED_SPACE_TAB      (line:  20, col:  12):	[93mMixed spaces and tabs[0m
-Error: TAB_INSTEAD_SPC      (line:  20, col:  13):	[94mFound tab when expecting space[0m
-Error: WRONG_SCOPE_VAR      (line:  21, col:   1):	[0mVariable declared in incorrect scope[0m
-Error: BRACE_NEWLINE        (line:  26, col:  16):	[93mExpected newline before brace[0m
-Error: SPC_AFTER_POINTER    (line:  27, col:  11):	[94mspace after pointer[0m
-Error: SPC_AFTER_POINTER    (line:  27, col:  13):	[94mspace after pointer[0m
-Error: NL_AFTER_VAR_DECL    (line:  28, col:  21):	[0mVariable declarations must be followed by a newline[0m
-Error: TOO_FEW_TAB          (line:  28, col:  21):	[0mMissing tabs for indent level[0m
-Error: TOO_MANY_INSTR       (line:  28, col:  21):	[0mToo many instructions on a single line[0m
-Error: MIXED_SPACE_TAB      (line:  28, col:  23):	[93mMixed spaces and tabs[0m
-Error: TAB_INSTEAD_SPC      (line:  28, col:  24):	[94mFound tab when expecting space[0m
-Error: NO_SPC_AFR_PAR       (line:  28, col:  58):	[94mExtra space after parenthesis (brace/bracket)[0m
-Error: TOO_FEW_TAB          (line:  28, col:  60):	[0mMissing tabs for indent level[0m
-Error: MIXED_SPACE_TAB      (line:  29, col:  12):	[93mMixed spaces and tabs[0m
-Error: TAB_INSTEAD_SPC      (line:  29, col:  13):	[94mFound tab when expecting space[0m
-Error: BRACE_NEWLINE        (line:  33, col:  16):	[93mExpected newline before brace[0m
-Error: SPC_AFTER_POINTER    (line:  34, col:  11):	[94mspace after pointer[0m
-Error: SPC_AFTER_POINTER    (line:  34, col:  13):	[94mspace after pointer[0m
-Error: NL_AFTER_VAR_DECL    (line:  35, col:  21):	[0mVariable declarations must be followed by a newline[0m
-Error: TOO_FEW_TAB          (line:  35, col:  21):	[0mMissing tabs for indent level[0m
-Error: TOO_MANY_INSTR       (line:  35, col:  21):	[0mToo many instructions on a single line[0m
-Error: MIXED_SPACE_TAB      (line:  35, col:  23):	[93mMixed spaces and tabs[0m
-Error: TAB_INSTEAD_SPC      (line:  35, col:  24):	[94mFound tab when expecting space[0m
-Error: SPC_AFTER_POINTER    (line:  35, col:  56):	[94mspace after pointer[0m
-Error: MIXED_SPACE_TAB      (line:  36, col:  12):	[93mMixed spaces and tabs[0m
-Error: TAB_INSTEAD_SPC      (line:  36, col:  13):	[94mFound tab when expecting space[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: BRACE_NEWLINE        (line:   1, col:  16):	Expected newline before brace
+Error: SPC_AFTER_POINTER    (line:   2, col:  11):	space after pointer
+Error: SPC_AFTER_POINTER    (line:   2, col:  13):	space after pointer
+Error: NL_AFTER_VAR_DECL    (line:   3, col:  21):	Variable declarations must be followed by a newline
+Error: TOO_FEW_TAB          (line:   3, col:  21):	Missing tabs for indent level
+Error: TOO_MANY_INSTR       (line:   3, col:  21):	Too many instructions on a single line
+Error: BRACE_NEWLINE        (line:   6, col:  16):	Expected newline before brace
+Error: SPC_AFTER_POINTER    (line:   7, col:  11):	space after pointer
+Error: SPC_AFTER_POINTER    (line:   7, col:  13):	space after pointer
+Error: NL_AFTER_VAR_DECL    (line:   8, col:  21):	Variable declarations must be followed by a newline
+Error: TOO_FEW_TAB          (line:   8, col:  21):	Missing tabs for indent level
+Error: TOO_MANY_INSTR       (line:   8, col:  21):	Too many instructions on a single line
+Error: MIXED_SPACE_TAB      (line:   8, col:  23):	Mixed spaces and tabs
+Error: TAB_INSTEAD_SPC      (line:   8, col:  24):	Found tab when expecting space
+Error: MIXED_SPACE_TAB      (line:  10, col:  12):	Mixed spaces and tabs
+Error: TAB_INSTEAD_SPC      (line:  10, col:  13):	Found tab when expecting space
+Error: BRACE_NEWLINE        (line:  16, col:  16):	Expected newline before brace
+Error: SPC_AFTER_POINTER    (line:  17, col:  11):	space after pointer
+Error: SPC_AFTER_POINTER    (line:  17, col:  13):	space after pointer
+Error: NL_AFTER_VAR_DECL    (line:  18, col:  21):	Variable declarations must be followed by a newline
+Error: TOO_FEW_TAB          (line:  18, col:  21):	Missing tabs for indent level
+Error: TOO_MANY_INSTR       (line:  18, col:  21):	Too many instructions on a single line
+Error: MIXED_SPACE_TAB      (line:  18, col:  23):	Mixed spaces and tabs
+Error: TAB_INSTEAD_SPC      (line:  18, col:  24):	Found tab when expecting space
+Error: MIXED_SPACE_TAB      (line:  20, col:  12):	Mixed spaces and tabs
+Error: TAB_INSTEAD_SPC      (line:  20, col:  13):	Found tab when expecting space
+Error: WRONG_SCOPE_VAR      (line:  21, col:   1):	Variable declared in incorrect scope
+Error: BRACE_NEWLINE        (line:  26, col:  16):	Expected newline before brace
+Error: SPC_AFTER_POINTER    (line:  27, col:  11):	space after pointer
+Error: SPC_AFTER_POINTER    (line:  27, col:  13):	space after pointer
+Error: NL_AFTER_VAR_DECL    (line:  28, col:  21):	Variable declarations must be followed by a newline
+Error: TOO_FEW_TAB          (line:  28, col:  21):	Missing tabs for indent level
+Error: TOO_MANY_INSTR       (line:  28, col:  21):	Too many instructions on a single line
+Error: MIXED_SPACE_TAB      (line:  28, col:  23):	Mixed spaces and tabs
+Error: TAB_INSTEAD_SPC      (line:  28, col:  24):	Found tab when expecting space
+Error: NO_SPC_AFR_PAR       (line:  28, col:  58):	Extra space after parenthesis (brace/bracket)
+Error: TOO_FEW_TAB          (line:  28, col:  60):	Missing tabs for indent level
+Error: MIXED_SPACE_TAB      (line:  29, col:  12):	Mixed spaces and tabs
+Error: TAB_INSTEAD_SPC      (line:  29, col:  13):	Found tab when expecting space
+Error: BRACE_NEWLINE        (line:  33, col:  16):	Expected newline before brace
+Error: SPC_AFTER_POINTER    (line:  34, col:  11):	space after pointer
+Error: SPC_AFTER_POINTER    (line:  34, col:  13):	space after pointer
+Error: NL_AFTER_VAR_DECL    (line:  35, col:  21):	Variable declarations must be followed by a newline
+Error: TOO_FEW_TAB          (line:  35, col:  21):	Missing tabs for indent level
+Error: TOO_MANY_INSTR       (line:  35, col:  21):	Too many instructions on a single line
+Error: MIXED_SPACE_TAB      (line:  35, col:  23):	Mixed spaces and tabs
+Error: TAB_INSTEAD_SPC      (line:  35, col:  24):	Found tab when expecting space
+Error: SPC_AFTER_POINTER    (line:  35, col:  56):	space after pointer
+Error: MIXED_SPACE_TAB      (line:  36, col:  12):	Mixed spaces and tabs
+Error: TAB_INSTEAD_SPC      (line:  36, col:  13):	Found tab when expecting space

--- a/tests/rules/samples/ko_pointer3.out
+++ b/tests/rules/samples/ko_pointer3.out
@@ -58,51 +58,51 @@
 [36mko_pointer3.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 23":
 		<RBRACE> 
 ko_pointer3.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: BRACE_NEWLINE        (line:   1, col:  16):	[93mExpected newline before brace[0m
-Error: SPC_AFTER_POINTER    (line:   2, col:  11):	[94mspace after pointer[0m
-Error: SPC_AFTER_POINTER    (line:   2, col:  13):	[94mspace after pointer[0m
-Error: NL_AFTER_VAR_DECL    (line:   3, col:  21):	[0mVariable declarations must be followed by a newline[0m
-Error: TOO_FEW_TAB          (line:   3, col:  21):	[0mMissing tabs for indent level[0m
-Error: TOO_MANY_INSTR       (line:   3, col:  21):	[0mToo many instructions on a single line[0m
-Error: MIXED_SPACE_TAB      (line:   3, col:  23):	[93mMixed spaces and tabs[0m
-Error: TAB_INSTEAD_SPC      (line:   3, col:  24):	[94mFound tab when expecting space[0m
-Error: SPC_AFTER_POINTER    (line:   3, col:  56):	[94mspace after pointer[0m
-Error: SPC_AFTER_POINTER    (line:   3, col:  57):	[94mspace after pointer[0m
-Error: MIXED_SPACE_TAB      (line:   4, col:  12):	[93mMixed spaces and tabs[0m
-Error: TAB_INSTEAD_SPC      (line:   4, col:  13):	[94mFound tab when expecting space[0m
-Error: BRACE_NEWLINE        (line:   7, col:  16):	[93mExpected newline before brace[0m
-Error: SPC_AFTER_POINTER    (line:   8, col:  11):	[94mspace after pointer[0m
-Error: SPC_AFTER_POINTER    (line:   8, col:  13):	[94mspace after pointer[0m
-Error: NL_AFTER_VAR_DECL    (line:   9, col:  21):	[0mVariable declarations must be followed by a newline[0m
-Error: TOO_FEW_TAB          (line:   9, col:  21):	[0mMissing tabs for indent level[0m
-Error: TOO_MANY_INSTR       (line:   9, col:  21):	[0mToo many instructions on a single line[0m
-Error: MIXED_SPACE_TAB      (line:   9, col:  23):	[93mMixed spaces and tabs[0m
-Error: TAB_INSTEAD_SPC      (line:   9, col:  24):	[94mFound tab when expecting space[0m
-Error: MIXED_SPACE_TAB      (line:  10, col:  12):	[93mMixed spaces and tabs[0m
-Error: TAB_INSTEAD_SPC      (line:  10, col:  13):	[94mFound tab when expecting space[0m
-Error: BRACE_NEWLINE        (line:  13, col:  16):	[93mExpected newline before brace[0m
-Error: SPC_AFTER_POINTER    (line:  14, col:  11):	[94mspace after pointer[0m
-Error: SPC_AFTER_POINTER    (line:  14, col:  13):	[94mspace after pointer[0m
-Error: NL_AFTER_VAR_DECL    (line:  15, col:  21):	[0mVariable declarations must be followed by a newline[0m
-Error: TOO_FEW_TAB          (line:  15, col:  21):	[0mMissing tabs for indent level[0m
-Error: TOO_MANY_INSTR       (line:  15, col:  21):	[0mToo many instructions on a single line[0m
-Error: NO_SPC_AFR_PAR       (line:  15, col:  38):	[94mExtra space after parenthesis (brace/bracket)[0m
-Error: NO_SPC_AFR_PAR       (line:  15, col:  40):	[94mExtra space after parenthesis (brace/bracket)[0m
-Error: NO_SPC_BFR_PAR       (line:  15, col:  40):	[94mExtra space before parenthesis (brace/bracket)[0m
-Error: NO_SPC_AFR_PAR       (line:  15, col:  42):	[94mExtra space after parenthesis (brace/bracket)[0m
-Error: NO_SPC_BFR_PAR       (line:  15, col:  42):	[94mExtra space before parenthesis (brace/bracket)[0m
-Error: NO_SPC_BFR_PAR       (line:  15, col:  44):	[94mExtra space before parenthesis (brace/bracket)[0m
-Error: MIXED_SPACE_TAB      (line:  16, col:   8):	[93mMixed spaces and tabs[0m
-Error: TAB_INSTEAD_SPC      (line:  16, col:   9):	[94mFound tab when expecting space[0m
-Error: NO_SPC_BFR_PAR       (line:  16, col:  33):	[94mExtra space before parenthesis (brace/bracket)[0m
-Error: BRACE_NEWLINE        (line:  19, col:  16):	[93mExpected newline before brace[0m
-Error: TAB_REPLACE_SPACE    (line:  20, col:   8):	[0mFound tab when expecting space[0m
-Error: SPACE_REPLACE_TAB    (line:  20, col:  13):	[0mFound space when expecting tab[0m
-Error: TOO_FEW_TAB          (line:  21, col:   1):	[0mMissing tabs for indent level[0m
-Error: SPC_AFTER_POINTER    (line:  21, col:   5):	[94mspace after pointer[0m
-Error: MIXED_SPACE_TAB      (line:  21, col:   6):	[93mMixed spaces and tabs[0m
-Error: SPC_AFTER_POINTER    (line:  21, col:  10):	[94mspace after pointer[0m
-Error: SPC_AFTER_POINTER    (line:  21, col:  12):	[94mspace after pointer[0m
-Error: SPC_AFTER_POINTER    (line:  21, col:  14):	[94mspace after pointer[0m
-Error: BRACE_SHOULD_EOL     (line:  23, col:   1):	[0mExpected newline after brace[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: BRACE_NEWLINE        (line:   1, col:  16):	Expected newline before brace
+Error: SPC_AFTER_POINTER    (line:   2, col:  11):	space after pointer
+Error: SPC_AFTER_POINTER    (line:   2, col:  13):	space after pointer
+Error: NL_AFTER_VAR_DECL    (line:   3, col:  21):	Variable declarations must be followed by a newline
+Error: TOO_FEW_TAB          (line:   3, col:  21):	Missing tabs for indent level
+Error: TOO_MANY_INSTR       (line:   3, col:  21):	Too many instructions on a single line
+Error: MIXED_SPACE_TAB      (line:   3, col:  23):	Mixed spaces and tabs
+Error: TAB_INSTEAD_SPC      (line:   3, col:  24):	Found tab when expecting space
+Error: SPC_AFTER_POINTER    (line:   3, col:  56):	space after pointer
+Error: SPC_AFTER_POINTER    (line:   3, col:  57):	space after pointer
+Error: MIXED_SPACE_TAB      (line:   4, col:  12):	Mixed spaces and tabs
+Error: TAB_INSTEAD_SPC      (line:   4, col:  13):	Found tab when expecting space
+Error: BRACE_NEWLINE        (line:   7, col:  16):	Expected newline before brace
+Error: SPC_AFTER_POINTER    (line:   8, col:  11):	space after pointer
+Error: SPC_AFTER_POINTER    (line:   8, col:  13):	space after pointer
+Error: NL_AFTER_VAR_DECL    (line:   9, col:  21):	Variable declarations must be followed by a newline
+Error: TOO_FEW_TAB          (line:   9, col:  21):	Missing tabs for indent level
+Error: TOO_MANY_INSTR       (line:   9, col:  21):	Too many instructions on a single line
+Error: MIXED_SPACE_TAB      (line:   9, col:  23):	Mixed spaces and tabs
+Error: TAB_INSTEAD_SPC      (line:   9, col:  24):	Found tab when expecting space
+Error: MIXED_SPACE_TAB      (line:  10, col:  12):	Mixed spaces and tabs
+Error: TAB_INSTEAD_SPC      (line:  10, col:  13):	Found tab when expecting space
+Error: BRACE_NEWLINE        (line:  13, col:  16):	Expected newline before brace
+Error: SPC_AFTER_POINTER    (line:  14, col:  11):	space after pointer
+Error: SPC_AFTER_POINTER    (line:  14, col:  13):	space after pointer
+Error: NL_AFTER_VAR_DECL    (line:  15, col:  21):	Variable declarations must be followed by a newline
+Error: TOO_FEW_TAB          (line:  15, col:  21):	Missing tabs for indent level
+Error: TOO_MANY_INSTR       (line:  15, col:  21):	Too many instructions on a single line
+Error: NO_SPC_AFR_PAR       (line:  15, col:  38):	Extra space after parenthesis (brace/bracket)
+Error: NO_SPC_AFR_PAR       (line:  15, col:  40):	Extra space after parenthesis (brace/bracket)
+Error: NO_SPC_BFR_PAR       (line:  15, col:  40):	Extra space before parenthesis (brace/bracket)
+Error: NO_SPC_AFR_PAR       (line:  15, col:  42):	Extra space after parenthesis (brace/bracket)
+Error: NO_SPC_BFR_PAR       (line:  15, col:  42):	Extra space before parenthesis (brace/bracket)
+Error: NO_SPC_BFR_PAR       (line:  15, col:  44):	Extra space before parenthesis (brace/bracket)
+Error: MIXED_SPACE_TAB      (line:  16, col:   8):	Mixed spaces and tabs
+Error: TAB_INSTEAD_SPC      (line:  16, col:   9):	Found tab when expecting space
+Error: NO_SPC_BFR_PAR       (line:  16, col:  33):	Extra space before parenthesis (brace/bracket)
+Error: BRACE_NEWLINE        (line:  19, col:  16):	Expected newline before brace
+Error: TAB_REPLACE_SPACE    (line:  20, col:   8):	Found tab when expecting space
+Error: SPACE_REPLACE_TAB    (line:  20, col:  13):	Found space when expecting tab
+Error: TOO_FEW_TAB          (line:  21, col:   1):	Missing tabs for indent level
+Error: SPC_AFTER_POINTER    (line:  21, col:   5):	space after pointer
+Error: MIXED_SPACE_TAB      (line:  21, col:   6):	Mixed spaces and tabs
+Error: SPC_AFTER_POINTER    (line:  21, col:  10):	space after pointer
+Error: SPC_AFTER_POINTER    (line:  21, col:  12):	space after pointer
+Error: SPC_AFTER_POINTER    (line:  21, col:  14):	space after pointer
+Error: BRACE_SHOULD_EOL     (line:  23, col:   1):	Expected newline after brace

--- a/tests/rules/samples/ko_preproc_define.out
+++ b/tests/rules/samples/ko_preproc_define.out
@@ -11,11 +11,11 @@
 [36mko_preproc_define.c[0m - [32mIsPreprocessorStatement[0m In "GlobalScope" from "None" line 6":
 		<SPACE> <HASH> <IDENTIFIER=define> <SPACE> <IDENTIFIER=TOTo> <SPACE> <IDENTIFIER=TATa> 
 ko_preproc_define.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: MACRO_NAME_CAPITAL   (line:   1, col:   9):	[0mMacro name must be capitalized[0m
-Error: PREPROC_CONSTANT     (line:   1, col:  15):	[0mPreprocessor statement must only contain constant defines[0m
-Error: PREPROC_CONSTANT     (line:   2, col:  13):	[0mPreprocessor statement must only contain constant defines[0m
-Error: PREPROC_CONSTANT     (line:   3, col:  22):	[0mPreprocessor statement must only contain constant defines[0m
-Error: PREPROC_CONSTANT     (line:   5, col:  19):	[0mPreprocessor statement must only contain constant defines[0m
-Error: PREPROC_START_LINE   (line:   6, col:   2):	[0mPreprocessor statement not at the beginning of the line[0m
-Error: MACRO_NAME_CAPITAL   (line:   6, col:  10):	[0mMacro name must be capitalized[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: MACRO_NAME_CAPITAL   (line:   1, col:   9):	Macro name must be capitalized
+Error: PREPROC_CONSTANT     (line:   1, col:  15):	Preprocessor statement must only contain constant defines
+Error: PREPROC_CONSTANT     (line:   2, col:  13):	Preprocessor statement must only contain constant defines
+Error: PREPROC_CONSTANT     (line:   3, col:  22):	Preprocessor statement must only contain constant defines
+Error: PREPROC_CONSTANT     (line:   5, col:  19):	Preprocessor statement must only contain constant defines
+Error: PREPROC_START_LINE   (line:   6, col:   2):	Preprocessor statement not at the beginning of the line
+Error: MACRO_NAME_CAPITAL   (line:   6, col:  10):	Macro name must be capitalized

--- a/tests/rules/samples/ko_preproc_indent.out
+++ b/tests/rules/samples/ko_preproc_indent.out
@@ -9,8 +9,8 @@
 [36mko_preproc_indent.c[0m - [32mIsPreprocessorStatement[0m In "GlobalScope" from "None" line 5":
 		<HASH> <SPACE> <SPACE> <SPACE> <IDENTIFIER=define> <SPACE> <IDENTIFIER=BAR> <SPACE> <CONSTANT=3> <NEWLINE>
 ko_preproc_indent.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: TOO_MANY_WS          (line:   1, col:   1):	[0mExtra whitespaces for indent level[0m
-Error: PREPROC_BAD_INDENT   (line:   3, col:   1):	[0mBad preprocessor indentation[0m
-Error: TOO_MANY_WS          (line:   4, col:   1):	[0mExtra whitespaces for indent level[0m
-Error: TOO_MANY_WS          (line:   5, col:   1):	[0mExtra whitespaces for indent level[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: TOO_MANY_WS          (line:   1, col:   1):	Extra whitespaces for indent level
+Error: PREPROC_BAD_INDENT   (line:   3, col:   1):	Bad preprocessor indentation
+Error: TOO_MANY_WS          (line:   4, col:   1):	Extra whitespaces for indent level
+Error: TOO_MANY_WS          (line:   5, col:   1):	Extra whitespaces for indent level

--- a/tests/rules/samples/ko_struct_indent.out
+++ b/tests/rules/samples/ko_struct_indent.out
@@ -29,16 +29,16 @@
 [36mko_struct_indent.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 15":
 		<RBRACE> <NEWLINE>
 ko_struct_indent.c: Error!
-Error: FORBIDDEN_TYPEDEF    (line:   1, col:   1):	[0mTypedef declaration are not allowed in .c files[0m
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
+Error: FORBIDDEN_TYPEDEF    (line:   1, col:   1):	Typedef declaration are not allowed in .c files
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
 Notice: GLOBAL_VAR_DETECTED  (line:   2, col:   1):	Global variable present in file. Make sure it is a reasonable choice.
-Error: GLOBAL_VAR_NAMING    (line:   2, col:  29):	[0mGlobal variable must start with g_[0m
-Error: MISALIGNED_VAR_DECL  (line:   2, col:  29):	[0mMisaligned variable declaration[0m
+Error: GLOBAL_VAR_NAMING    (line:   2, col:  29):	Global variable must start with g_
+Error: MISALIGNED_VAR_DECL  (line:   2, col:  29):	Misaligned variable declaration
 Notice: GLOBAL_VAR_DETECTED  (line:   3, col:   1):	Global variable present in file. Make sure it is a reasonable choice.
-Error: MISALIGNED_VAR_DECL  (line:   3, col:  29):	[0mMisaligned variable declaration[0m
-Error: MULT_DECL_LINE       (line:   3, col:  34):	[0mMultiple declarations on a single line[0m
-Error: FORBIDDEN_TYPEDEF    (line:   5, col:   1):	[0mTypedef declaration are not allowed in .c files[0m
-Error: BRACE_NEWLINE        (line:   5, col:  23):	[93mExpected newline before brace[0m
-Error: MISALIGNED_VAR_DECL  (line:   7, col:  29):	[0mMisaligned variable declaration[0m
-Error: MISALIGNED_VAR_DECL  (line:   8, col:   1):	[0mMisaligned variable declaration[0m
-Error: MISALIGNED_VAR_DECL  (line:   9, col:  29):	[0mMisaligned variable declaration[0m
+Error: MISALIGNED_VAR_DECL  (line:   3, col:  29):	Misaligned variable declaration
+Error: MULT_DECL_LINE       (line:   3, col:  34):	Multiple declarations on a single line
+Error: FORBIDDEN_TYPEDEF    (line:   5, col:   1):	Typedef declaration are not allowed in .c files
+Error: BRACE_NEWLINE        (line:   5, col:  23):	Expected newline before brace
+Error: MISALIGNED_VAR_DECL  (line:   7, col:  29):	Misaligned variable declaration
+Error: MISALIGNED_VAR_DECL  (line:   8, col:   1):	Misaligned variable declaration
+Error: MISALIGNED_VAR_DECL  (line:   9, col:  29):	Misaligned variable declaration

--- a/tests/rules/samples/ko_struct_name.out
+++ b/tests/rules/samples/ko_struct_name.out
@@ -39,16 +39,16 @@
 [36mko_struct_name.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 20":
 		<RBRACE> <NEWLINE>
 ko_struct_name.c: Error!
-Error: FORBIDDEN_TYPEDEF    (line:   1, col:   1):	[0mTypedef declaration are not allowed in .c files[0m
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: USER_DEFINED_TYPEDEF (line:   1, col:  25):	[0mUser defined typedef must start with t_[0m
+Error: FORBIDDEN_TYPEDEF    (line:   1, col:   1):	Typedef declaration are not allowed in .c files
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: USER_DEFINED_TYPEDEF (line:   1, col:  25):	User defined typedef must start with t_
 Notice: GLOBAL_VAR_DETECTED  (line:   2, col:   1):	Global variable present in file. Make sure it is a reasonable choice.
-Error: GLOBAL_VAR_NAMING    (line:   2, col:  25):	[0mGlobal variable must start with g_[0m
+Error: GLOBAL_VAR_NAMING    (line:   2, col:  25):	Global variable must start with g_
 Notice: GLOBAL_VAR_DETECTED  (line:   3, col:   1):	Global variable present in file. Make sure it is a reasonable choice.
-Error: GLOBAL_VAR_NAMING    (line:   3, col:  25):	[0mGlobal variable must start with g_[0m
-Error: FORBIDDEN_TYPEDEF    (line:   5, col:   1):	[0mTypedef declaration are not allowed in .c files[0m
-Error: BRACE_NEWLINE        (line:   5, col:  21):	[93mExpected newline before brace[0m
-Error: USER_DEFINED_TYPEDEF (line:   8, col:  25):	[0mUser defined typedef must start with t_[0m
-Error: USER_DEFINED_TYPEDEF (line:  10, col:   5):	[0mUser defined typedef must start with t_[0m
-Error: FORBIDDEN_TYPEDEF    (line:  12, col:   1):	[0mTypedef declaration are not allowed in .c files[0m
-Error: NO_TAB_BF_TYPEDEF    (line:  15, col:   2):	[0mMissing whitespace before typedef name[0m
+Error: GLOBAL_VAR_NAMING    (line:   3, col:  25):	Global variable must start with g_
+Error: FORBIDDEN_TYPEDEF    (line:   5, col:   1):	Typedef declaration are not allowed in .c files
+Error: BRACE_NEWLINE        (line:   5, col:  21):	Expected newline before brace
+Error: USER_DEFINED_TYPEDEF (line:   8, col:  25):	User defined typedef must start with t_
+Error: USER_DEFINED_TYPEDEF (line:  10, col:   5):	User defined typedef must start with t_
+Error: FORBIDDEN_TYPEDEF    (line:  12, col:   1):	Typedef declaration are not allowed in .c files
+Error: NO_TAB_BF_TYPEDEF    (line:  15, col:   2):	Missing whitespace before typedef name

--- a/tests/rules/samples/ko_too_many_arg.out
+++ b/tests/rules/samples/ko_too_many_arg.out
@@ -7,5 +7,5 @@
 [36mko_too_many_arg.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 4":
 		<RBRACE> <NEWLINE>
 ko_too_many_arg.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: TOO_MANY_ARGS        (line:   1, col:  71):	[91mFunction has more than 4 arguments[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: TOO_MANY_ARGS        (line:   1, col:  71):	Function has more than 4 arguments

--- a/tests/rules/samples/ko_too_many_instruction.out
+++ b/tests/rules/samples/ko_too_many_instruction.out
@@ -16,9 +16,9 @@
 		<RBRACE> <NEWLINE>
 ko_too_many_instruction.c: Error!
 Notice: GLOBAL_VAR_DETECTED  (line:   1, col:   1):	Global variable present in file. Make sure it is a reasonable choice.
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
 Notice: GLOBAL_VAR_DETECTED  (line:   1, col:  10):	Global variable present in file. Make sure it is a reasonable choice.
-Error: TOO_MANY_INSTR       (line:   1, col:  10):	[0mToo many instructions on a single line[0m
-Error: MISALIGNED_VAR_DECL  (line:   1, col:  17):	[0mMisaligned variable declaration[0m
-Error: TOO_FEW_TAB          (line:   5, col:  23):	[0mMissing tabs for indent level[0m
-Error: TOO_MANY_INSTR       (line:   5, col:  23):	[0mToo many instructions on a single line[0m
+Error: TOO_MANY_INSTR       (line:   1, col:  10):	Too many instructions on a single line
+Error: MISALIGNED_VAR_DECL  (line:   1, col:  17):	Misaligned variable declaration
+Error: TOO_FEW_TAB          (line:   5, col:  23):	Missing tabs for indent level
+Error: TOO_MANY_INSTR       (line:   5, col:  23):	Too many instructions on a single line

--- a/tests/rules/samples/ko_var_decl.out
+++ b/tests/rules/samples/ko_var_decl.out
@@ -37,5 +37,5 @@
 [36mko_var_decl.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 19":
 		<RBRACE> <NEWLINE>
 ko_var_decl.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: MULT_IN_SINGLE_INSTR (line:   9, col:   1):	[0mMultiple instructions in single line control structure[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: MULT_IN_SINGLE_INSTR (line:   9, col:   1):	Multiple instructions in single line control structure

--- a/tests/rules/samples/ko_var_name.out
+++ b/tests/rules/samples/ko_var_name.out
@@ -4,11 +4,11 @@
 		<INT> <SPACE> <IDENTIFIER=NotValidEither> <SEMI_COLON> <NEWLINE>
 ko_var_name.c: Error!
 Notice: GLOBAL_VAR_DETECTED  (line:   1, col:   1):	Global variable present in file. Make sure it is a reasonable choice.
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: SPACE_REPLACE_TAB    (line:   1, col:   4):	[0mFound space when expecting tab[0m
-Error: FORBIDDEN_CHAR_NAME  (line:   1, col:   5):	[0muser defined identifiers should contain only lowercase characters, digits or '_'[0m
-Error: GLOBAL_VAR_NAMING    (line:   1, col:   5):	[0mGlobal variable must start with g_[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: SPACE_REPLACE_TAB    (line:   1, col:   4):	Found space when expecting tab
+Error: FORBIDDEN_CHAR_NAME  (line:   1, col:   5):	user defined identifiers should contain only lowercase characters, digits or '_'
+Error: GLOBAL_VAR_NAMING    (line:   1, col:   5):	Global variable must start with g_
 Notice: GLOBAL_VAR_DETECTED  (line:   2, col:   1):	Global variable present in file. Make sure it is a reasonable choice.
-Error: SPACE_REPLACE_TAB    (line:   2, col:   4):	[0mFound space when expecting tab[0m
-Error: FORBIDDEN_CHAR_NAME  (line:   2, col:   5):	[0muser defined identifiers should contain only lowercase characters, digits or '_'[0m
-Error: GLOBAL_VAR_NAMING    (line:   2, col:   5):	[0mGlobal variable must start with g_[0m
+Error: SPACE_REPLACE_TAB    (line:   2, col:   4):	Found space when expecting tab
+Error: FORBIDDEN_CHAR_NAME  (line:   2, col:   5):	user defined identifiers should contain only lowercase characters, digits or '_'
+Error: GLOBAL_VAR_NAMING    (line:   2, col:   5):	Global variable must start with g_

--- a/tests/rules/samples/ko_white_space_end_include.out
+++ b/tests/rules/samples/ko_white_space_end_include.out
@@ -17,6 +17,6 @@
 [36mko_white_space_end_include.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 9":
 		<RBRACE> <SPACE> <NEWLINE>
 ko_white_space_end_include.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: SPC_BEFORE_NL        (line:   5, col:   2):	[0mSpace before newline[0m
-Error: SPC_BEFORE_NL        (line:   9, col:   2):	[0mSpace before newline[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: SPC_BEFORE_NL        (line:   5, col:   2):	Space before newline
+Error: SPC_BEFORE_NL        (line:   9, col:   2):	Space before newline

--- a/tests/rules/samples/ko_white_space_eof.out
+++ b/tests/rules/samples/ko_white_space_eof.out
@@ -13,5 +13,5 @@
 [36mko_white_space_eof.c[0m - [32mIsEmptyLine[0m In "GlobalScope" from "None" line 7":
 		<TAB> 
 ko_white_space_eof.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: SPACE_EMPTY_LINE     (line:   7, col:   1):	[0mSpace on empty line[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: SPACE_EMPTY_LINE     (line:   7, col:   1):	Space on empty line

--- a/tests/rules/samples/long_test.out
+++ b/tests/rules/samples/long_test.out
@@ -143,69 +143,69 @@
 [36mlong_test.c[0m - [32mIsFunctionCall[0m In "GlobalScope" from "None" line 63":
 		<MULT> <MULT> <MULT> <IDENTIFIER=func4> <LPARENTHESIS> <IDENTIFIER=udidf> <SPACE> <IDENTIFIER=fdfd> <RPARENTHESIS> <SEMI_COLON> <NEWLINE>
 long_test.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: TOO_MANY_TAB         (line:   4, col:   1):	[0mExtra tabs for indent level[0m
-Error: EMPTY_LINE_FUNCTION  (line:   5, col:   1):	[0mEmpty line in function[0m
-Error: SPACE_EMPTY_LINE     (line:   5, col:   1):	[0mSpace on empty line[0m
-Error: TOO_FEW_TAB          (line:   6, col:   1):	[0mMissing tabs for indent level[0m
-Error: SPACE_BEFORE_FUNC    (line:  10, col:  10):	[94mspace before function name[0m
-Error: NO_ARGS_VOID         (line:  10, col:  13):	[0mEmpty function argument requires void[0m
-Error: BRACE_NEWLINE        (line:  10, col:  15):	[93mExpected newline before brace[0m
-Error: BRACE_SHOULD_EOL     (line:  10, col:  16):	[0mExpected newline after brace[0m
-Error: TOO_FEW_TAB          (line:  10, col:  17):	[0mMissing tabs for indent level[0m
-Error: TOO_FEW_TAB          (line:  10, col:  17):	[0mMissing tabs for indent level[0m
-Error: TOO_MANY_INSTR       (line:  10, col:  17):	[0mToo many instructions on a single line[0m
-Error: RETURN_PARENTHESIS   (line:  10, col:  24):	[0mReturn value must be in parenthesis[0m
-Error: TOO_MANY_INSTR       (line:  10, col:  27):	[0mToo many instructions on a single line[0m
-Error: SPACE_BEFORE_FUNC    (line:  12, col:   4):	[94mspace before function name[0m
-Error: RETURN_PARENTHESIS   (line:  14, col:  12):	[0mReturn value must be in parenthesis[0m
-Error: INCLUDE_START_FILE   (line:  17, col:   1):	[0mInclude must be at the start of file[0m
-Error: NL_AFTER_PREPROC     (line:  18, col:   1):	[0mPreprocessor statement must be followed by a newline[0m
-Error: NO_ARGS_VOID         (line:  18, col:  11):	[0mEmpty function argument requires void[0m
-Error: RETURN_PARENTHESIS   (line:  20, col:  12):	[0mReturn value must be in parenthesis[0m
-Error: SPACE_BEFORE_FUNC    (line:  23, col:   4):	[94mspace before function name[0m
-Error: MISSING_IDENTIFIER   (line:  23, col:  16):	[0mmissing type qualifier or identifier in function arguments[0m
-Error: BRACE_NEWLINE        (line:  23, col:  22):	[93mExpected newline before brace[0m
-Error: RETURN_PARENTHESIS   (line:  24, col:  12):	[0mReturn value must be in parenthesis[0m
-Error: TOO_MANY_INSTR       (line:  24, col:  17):	[0mToo many instructions on a single line[0m
-Error: TOO_MANY_FUNCS       (line:  26, col:   1):	[92mToo many functions in file[0m
-Error: MISSING_IDENTIFIER   (line:  26, col:  28):	[0mmissing type qualifier or identifier in function arguments[0m
-Error: TOO_MANY_FUNCS       (line:  31, col:   1):	[92mToo many functions in file[0m
-Error: MISSING_IDENTIFIER   (line:  31, col:  33):	[0mmissing type qualifier or identifier in function arguments[0m
-Error: BRACE_NEWLINE        (line:  31, col:  39):	[93mExpected newline before brace[0m
-Error: BRACE_SHOULD_EOL     (line:  31, col:  40):	[0mExpected newline after brace[0m
-Error: TOO_FEW_TAB          (line:  31, col:  41):	[0mMissing tabs for indent level[0m
-Error: TOO_FEW_TAB          (line:  31, col:  41):	[0mMissing tabs for indent level[0m
-Error: TOO_MANY_INSTR       (line:  31, col:  41):	[0mToo many instructions on a single line[0m
-Error: RETURN_PARENTHESIS   (line:  31, col:  48):	[0mReturn value must be in parenthesis[0m
-Error: TOO_MANY_INSTR       (line:  31, col:  52):	[0mToo many instructions on a single line[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: TOO_MANY_TAB         (line:   4, col:   1):	Extra tabs for indent level
+Error: EMPTY_LINE_FUNCTION  (line:   5, col:   1):	Empty line in function
+Error: SPACE_EMPTY_LINE     (line:   5, col:   1):	Space on empty line
+Error: TOO_FEW_TAB          (line:   6, col:   1):	Missing tabs for indent level
+Error: SPACE_BEFORE_FUNC    (line:  10, col:  10):	space before function name
+Error: NO_ARGS_VOID         (line:  10, col:  13):	Empty function argument requires void
+Error: BRACE_NEWLINE        (line:  10, col:  15):	Expected newline before brace
+Error: BRACE_SHOULD_EOL     (line:  10, col:  16):	Expected newline after brace
+Error: TOO_FEW_TAB          (line:  10, col:  17):	Missing tabs for indent level
+Error: TOO_FEW_TAB          (line:  10, col:  17):	Missing tabs for indent level
+Error: TOO_MANY_INSTR       (line:  10, col:  17):	Too many instructions on a single line
+Error: RETURN_PARENTHESIS   (line:  10, col:  24):	Return value must be in parenthesis
+Error: TOO_MANY_INSTR       (line:  10, col:  27):	Too many instructions on a single line
+Error: SPACE_BEFORE_FUNC    (line:  12, col:   4):	space before function name
+Error: RETURN_PARENTHESIS   (line:  14, col:  12):	Return value must be in parenthesis
+Error: INCLUDE_START_FILE   (line:  17, col:   1):	Include must be at the start of file
+Error: NL_AFTER_PREPROC     (line:  18, col:   1):	Preprocessor statement must be followed by a newline
+Error: NO_ARGS_VOID         (line:  18, col:  11):	Empty function argument requires void
+Error: RETURN_PARENTHESIS   (line:  20, col:  12):	Return value must be in parenthesis
+Error: SPACE_BEFORE_FUNC    (line:  23, col:   4):	space before function name
+Error: MISSING_IDENTIFIER   (line:  23, col:  16):	missing type qualifier or identifier in function arguments
+Error: BRACE_NEWLINE        (line:  23, col:  22):	Expected newline before brace
+Error: RETURN_PARENTHESIS   (line:  24, col:  12):	Return value must be in parenthesis
+Error: TOO_MANY_INSTR       (line:  24, col:  17):	Too many instructions on a single line
+Error: TOO_MANY_FUNCS       (line:  26, col:   1):	Too many functions in file
+Error: MISSING_IDENTIFIER   (line:  26, col:  28):	missing type qualifier or identifier in function arguments
+Error: TOO_MANY_FUNCS       (line:  31, col:   1):	Too many functions in file
+Error: MISSING_IDENTIFIER   (line:  31, col:  33):	missing type qualifier or identifier in function arguments
+Error: BRACE_NEWLINE        (line:  31, col:  39):	Expected newline before brace
+Error: BRACE_SHOULD_EOL     (line:  31, col:  40):	Expected newline after brace
+Error: TOO_FEW_TAB          (line:  31, col:  41):	Missing tabs for indent level
+Error: TOO_FEW_TAB          (line:  31, col:  41):	Missing tabs for indent level
+Error: TOO_MANY_INSTR       (line:  31, col:  41):	Too many instructions on a single line
+Error: RETURN_PARENTHESIS   (line:  31, col:  48):	Return value must be in parenthesis
+Error: TOO_MANY_INSTR       (line:  31, col:  52):	Too many instructions on a single line
 Notice: GLOBAL_VAR_DETECTED  (line:  33, col:   1):	Global variable present in file. Make sure it is a reasonable choice.
-Error: GLOBAL_VAR_NAMING    (line:  33, col:   7):	[0mGlobal variable must start with g_[0m
+Error: GLOBAL_VAR_NAMING    (line:  33, col:   7):	Global variable must start with g_
 Notice: GLOBAL_VAR_DETECTED  (line:  34, col:   1):	Global variable present in file. Make sure it is a reasonable choice.
-Error: GLOBAL_VAR_NAMING    (line:  34, col:   9):	[0mGlobal variable must start with g_[0m
-Error: MISALIGNED_VAR_DECL  (line:  34, col:  19):	[0mMisaligned variable declaration[0m
+Error: GLOBAL_VAR_NAMING    (line:  34, col:   9):	Global variable must start with g_
+Error: MISALIGNED_VAR_DECL  (line:  34, col:  19):	Misaligned variable declaration
 Notice: GLOBAL_VAR_DETECTED  (line:  38, col:   1):	Global variable present in file. Make sure it is a reasonable choice.
-Error: SPACE_REPLACE_TAB    (line:  38, col:   4):	[0mFound space when expecting tab[0m
-Error: GLOBAL_VAR_NAMING    (line:  38, col:   8):	[0mGlobal variable must start with g_[0m
-Error: NO_SPC_AFR_PAR       (line:  38, col:  17):	[94mExtra space after parenthesis (brace/bracket)[0m
-Error: SPACE_REPLACE_TAB    (line:  39, col:   4):	[0mFound space when expecting tab[0m
-Error: EXP_PARENTHESIS      (line:  39, col:  10):	[94mExpected parenthesis[0m
-Error: FORBIDDEN_ENUM       (line:  40, col:   1):	[0mEnum declaration are not allowed in .c files[0m
-Error: ENUM_TYPE_NAMING     (line:  40, col:   6):	[0mEnum name must start with e_[0m
-Error: BRACE_NEWLINE        (line:  40, col:  10):	[93mExpected newline before brace[0m
-Error: MISALIGNED_FUNC_DECL (line:  46, col:  21):	[0mMisaligned function declaration[0m
-Error: MISALIGNED_FUNC_DECL (line:  47, col:  21):	[0mMisaligned function declaration[0m
-Error: MISALIGNED_FUNC_DECL (line:  48, col:  21):	[0mMisaligned function declaration[0m
-Error: MISALIGNED_FUNC_DECL (line:  49, col:  21):	[0mMisaligned function declaration[0m
-Error: SPACE_REPLACE_TAB    (line:  50, col:   2):	[0mFound space when expecting tab[0m
-Error: MISALIGNED_FUNC_DECL (line:  50, col:   9):	[0mMisaligned function declaration[0m
-Error: MISALIGNED_FUNC_DECL (line:  51, col:   9):	[0mMisaligned function declaration[0m
-Error: MISALIGNED_FUNC_DECL (line:  52, col:  17):	[0mMisaligned function declaration[0m
-Error: MISSING_IDENTIFIER   (line:  53, col:  30):	[0mmissing type qualifier or identifier in function arguments[0m
-Error: MISSING_IDENTIFIER   (line:  54, col:  26):	[0mmissing type qualifier or identifier in function arguments[0m
-Error: CONSECUTIVE_SPC      (line:  57, col:  43):	[94mTwo or more consecutives spaces[0m
-Error: SPC_AFTER_OPERATOR   (line:  58, col:  38):	[94mmissing space after operator[0m
-Error: SPC_AFTER_POINTER    (line:  60, col:  44):	[94mspace after pointer[0m
-Error: SPC_AFTER_POINTER    (line:  61, col:  47):	[94mspace after pointer[0m
-Error: SPC_AFTER_POINTER    (line:  61, col:  48):	[94mspace after pointer[0m
-Error: MISALIGNED_FUNC_DECL (line:  62, col:  21):	[0mMisaligned function declaration[0m
+Error: SPACE_REPLACE_TAB    (line:  38, col:   4):	Found space when expecting tab
+Error: GLOBAL_VAR_NAMING    (line:  38, col:   8):	Global variable must start with g_
+Error: NO_SPC_AFR_PAR       (line:  38, col:  17):	Extra space after parenthesis (brace/bracket)
+Error: SPACE_REPLACE_TAB    (line:  39, col:   4):	Found space when expecting tab
+Error: EXP_PARENTHESIS      (line:  39, col:  10):	Expected parenthesis
+Error: FORBIDDEN_ENUM       (line:  40, col:   1):	Enum declaration are not allowed in .c files
+Error: ENUM_TYPE_NAMING     (line:  40, col:   6):	Enum name must start with e_
+Error: BRACE_NEWLINE        (line:  40, col:  10):	Expected newline before brace
+Error: MISALIGNED_FUNC_DECL (line:  46, col:  21):	Misaligned function declaration
+Error: MISALIGNED_FUNC_DECL (line:  47, col:  21):	Misaligned function declaration
+Error: MISALIGNED_FUNC_DECL (line:  48, col:  21):	Misaligned function declaration
+Error: MISALIGNED_FUNC_DECL (line:  49, col:  21):	Misaligned function declaration
+Error: SPACE_REPLACE_TAB    (line:  50, col:   2):	Found space when expecting tab
+Error: MISALIGNED_FUNC_DECL (line:  50, col:   9):	Misaligned function declaration
+Error: MISALIGNED_FUNC_DECL (line:  51, col:   9):	Misaligned function declaration
+Error: MISALIGNED_FUNC_DECL (line:  52, col:  17):	Misaligned function declaration
+Error: MISSING_IDENTIFIER   (line:  53, col:  30):	missing type qualifier or identifier in function arguments
+Error: MISSING_IDENTIFIER   (line:  54, col:  26):	missing type qualifier or identifier in function arguments
+Error: CONSECUTIVE_SPC      (line:  57, col:  43):	Two or more consecutives spaces
+Error: SPC_AFTER_OPERATOR   (line:  58, col:  38):	missing space after operator
+Error: SPC_AFTER_POINTER    (line:  60, col:  44):	space after pointer
+Error: SPC_AFTER_POINTER    (line:  61, col:  47):	space after pointer
+Error: SPC_AFTER_POINTER    (line:  61, col:  48):	space after pointer
+Error: MISALIGNED_FUNC_DECL (line:  62, col:  21):	Misaligned function declaration

--- a/tests/rules/samples/ok_comment.out
+++ b/tests/rules/samples/ok_comment.out
@@ -31,5 +31,5 @@
 [36mok_comment.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 16":
 		<RBRACE> <NEWLINE>
 ok_comment.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
 Notice: GLOBAL_VAR_DETECTED  (line:   3, col:   1):	Global variable present in file. Make sure it is a reasonable choice.

--- a/tests/rules/samples/ok_const_ptr_1.out
+++ b/tests/rules/samples/ok_const_ptr_1.out
@@ -25,9 +25,9 @@
 [36mok_const_ptr_1.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 13":
 		<RBRACE> <NEWLINE>
 ok_const_ptr_1.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: TOO_MANY_VARS_FUNC   (line:   8, col:   1):	[91mToo many variables declarations in a function[0m
-Error: TOO_MANY_VARS_FUNC   (line:   9, col:   1):	[91mToo many variables declarations in a function[0m
-Error: TOO_MANY_VARS_FUNC   (line:  10, col:   1):	[91mToo many variables declarations in a function[0m
-Error: TOO_MANY_VARS_FUNC   (line:  11, col:   1):	[91mToo many variables declarations in a function[0m
-Error: TOO_MANY_VARS_FUNC   (line:  12, col:   1):	[91mToo many variables declarations in a function[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: TOO_MANY_VARS_FUNC   (line:   8, col:   1):	Too many variables declarations in a function
+Error: TOO_MANY_VARS_FUNC   (line:   9, col:   1):	Too many variables declarations in a function
+Error: TOO_MANY_VARS_FUNC   (line:  10, col:   1):	Too many variables declarations in a function
+Error: TOO_MANY_VARS_FUNC   (line:  11, col:   1):	Too many variables declarations in a function
+Error: TOO_MANY_VARS_FUNC   (line:  12, col:   1):	Too many variables declarations in a function

--- a/tests/rules/samples/ok_const_ptr_2.out
+++ b/tests/rules/samples/ok_const_ptr_2.out
@@ -37,4 +37,4 @@
 [36mok_const_ptr_2.h[0m - [32mIsPreprocessorStatement[0m In "GlobalScope" from "None" line 19":
 		<HASH> <IDENTIFIER=endif> <NEWLINE>
 ok_const_ptr_2.h: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header

--- a/tests/rules/samples/ok_cs_cs.out
+++ b/tests/rules/samples/ok_cs_cs.out
@@ -11,4 +11,4 @@
 [36mok_cs_cs.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 6":
 		<RBRACE> <NEWLINE>
 ok_cs_cs.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header

--- a/tests/rules/samples/ok_cs_indent.out
+++ b/tests/rules/samples/ok_cs_indent.out
@@ -19,4 +19,4 @@
 [36mok_cs_indent.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 10":
 		<RBRACE> <NEWLINE>
 ok_cs_indent.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header

--- a/tests/rules/samples/ok_enum.out
+++ b/tests/rules/samples/ok_enum.out
@@ -11,5 +11,5 @@
 [36mok_enum.c[0m - [32mIsBlockEnd[0m In "UserDefinedEnum" from "GlobalScope" line 6":
 		<RBRACE> <TAB> <IDENTIFIER=t_toto> <SEMI_COLON> <NEWLINE>
 ok_enum.c: Error!
-Error: FORBIDDEN_TYPEDEF    (line:   1, col:   1):	[0mTypedef declaration are not allowed in .c files[0m
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
+Error: FORBIDDEN_TYPEDEF    (line:   1, col:   1):	Typedef declaration are not allowed in .c files
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header

--- a/tests/rules/samples/ok_func_classic.out
+++ b/tests/rules/samples/ok_func_classic.out
@@ -83,5 +83,5 @@
 		<RBRACE> <NEWLINE>
 ok_func_classic.c: Error!
 Notice: GLOBAL_VAR_DETECTED  (line:   1, col:   1):	Global variable present in file. Make sure it is a reasonable choice.
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
 Error: CHAR_AS_STRING       (line:  48, col:  21):	Character constants can have only one character

--- a/tests/rules/samples/ok_func_name.out
+++ b/tests/rules/samples/ok_func_name.out
@@ -41,13 +41,13 @@
 [36mok_func_name.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 21":
 		<RBRACE> <NEWLINE>
 ok_func_name.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: FORBIDDEN_TYPEDEF    (line:   8, col:   1):	[0mTypedef declaration are not allowed in .c files[0m
-Error: FORBIDDEN_CHAR_NAME  (line:   8, col:  25):	[0muser defined identifiers should contain only lowercase characters, digits or '_'[0m
-Error: FORBIDDEN_STRUCT     (line:   9, col:   1):	[0mStruct declaration are not allowed in .c files[0m
-Error: FORBIDDEN_CHAR_NAME  (line:   9, col:  25):	[0muser defined identifiers should contain only lowercase characters, digits or '_'[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: FORBIDDEN_TYPEDEF    (line:   8, col:   1):	Typedef declaration are not allowed in .c files
+Error: FORBIDDEN_CHAR_NAME  (line:   8, col:  25):	user defined identifiers should contain only lowercase characters, digits or '_'
+Error: FORBIDDEN_STRUCT     (line:   9, col:   1):	Struct declaration are not allowed in .c files
+Error: FORBIDDEN_CHAR_NAME  (line:   9, col:  25):	user defined identifiers should contain only lowercase characters, digits or '_'
 Notice: GLOBAL_VAR_DETECTED  (line:  11, col:   1):	Global variable present in file. Make sure it is a reasonable choice.
-Error: FORBIDDEN_CHAR_NAME  (line:  11, col:  25):	[0muser defined identifiers should contain only lowercase characters, digits or '_'[0m
-Error: FORBIDDEN_CHAR_NAME  (line:  13, col:   5):	[0muser defined identifiers should contain only lowercase characters, digits or '_'[0m
-Error: FORBIDDEN_CHAR_NAME  (line:  15, col:  18):	[0muser defined identifiers should contain only lowercase characters, digits or '_'[0m
-Error: FORBIDDEN_CHAR_NAME  (line:  16, col:  17):	[0muser defined identifiers should contain only lowercase characters, digits or '_'[0m
+Error: FORBIDDEN_CHAR_NAME  (line:  11, col:  25):	user defined identifiers should contain only lowercase characters, digits or '_'
+Error: FORBIDDEN_CHAR_NAME  (line:  13, col:   5):	user defined identifiers should contain only lowercase characters, digits or '_'
+Error: FORBIDDEN_CHAR_NAME  (line:  15, col:  18):	user defined identifiers should contain only lowercase characters, digits or '_'
+Error: FORBIDDEN_CHAR_NAME  (line:  16, col:  17):	user defined identifiers should contain only lowercase characters, digits or '_'

--- a/tests/rules/samples/ok_func_ptr.out
+++ b/tests/rules/samples/ok_func_ptr.out
@@ -23,7 +23,7 @@
 [36mok_func_ptr.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 11":
 		<RBRACE> <NEWLINE>
 ok_func_ptr.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
 Notice: GLOBAL_VAR_DETECTED  (line:   2, col:   1):	Global variable present in file. Make sure it is a reasonable choice.
-Error: FORBIDDEN_TYPEDEF    (line:   5, col:   1):	[0mTypedef declaration are not allowed in .c files[0m
-Error: FORBIDDEN_TYPEDEF    (line:   6, col:   1):	[0mTypedef declaration are not allowed in .c files[0m
+Error: FORBIDDEN_TYPEDEF    (line:   5, col:   1):	Typedef declaration are not allowed in .c files
+Error: FORBIDDEN_TYPEDEF    (line:   6, col:   1):	Typedef declaration are not allowed in .c files

--- a/tests/rules/samples/ok_function_pointer.out
+++ b/tests/rules/samples/ok_function_pointer.out
@@ -5,4 +5,4 @@
 [36mok_function_pointer.c[0m - [32mIsAssignation[0m In "GlobalScope" from "None" line 3":
 		<IDENTIFIER=result> <SPACE> <ASSIGN> <SPACE> <LPARENTHESIS> <MULT> <IDENTIFIER=fpcomparer> <RPARENTHESIS> <LPARENTHESIS> <IDENTIFIER=a> <COMMA> <SPACE> <IDENTIFIER=a> <SPACE> <MULT> <SPACE> <MULT> <IDENTIFIER=b> <RPARENTHESIS> <SEMI_COLON> 
 ok_function_pointer.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header

--- a/tests/rules/samples/ok_if_defined.out
+++ b/tests/rules/samples/ok_if_defined.out
@@ -21,5 +21,5 @@
 [36mok_if_defined.c[0m - [32mIsFuncPrototype[0m In "GlobalScope" from "None" line 11":
 		<VOID> <TAB> <IDENTIFIER=defined> <LPARENTHESIS> <VOID> <RPARENTHESIS> <SEMI_COLON> <NEWLINE>
 ok_if_defined.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: PREPROC_CONSTANT     (line:   9, col:  19):	[0mPreprocessor statement must only contain constant defines[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: PREPROC_CONSTANT     (line:   9, col:  19):	Preprocessor statement must only contain constant defines

--- a/tests/rules/samples/ok_ifdef.out
+++ b/tests/rules/samples/ok_ifdef.out
@@ -15,7 +15,7 @@
 [36mok_ifdef.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 8":
 		<RBRACE> <NEWLINE>
 ok_ifdef.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: NL_AFTER_PREPROC     (line:   2, col:   1):	[0mPreprocessor statement must be followed by a newline[0m
-Error: NL_AFTER_PREPROC     (line:   4, col:   1):	[0mPreprocessor statement must be followed by a newline[0m
-Error: NL_AFTER_PREPROC     (line:   6, col:   1):	[0mPreprocessor statement must be followed by a newline[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: NL_AFTER_PREPROC     (line:   2, col:   1):	Preprocessor statement must be followed by a newline
+Error: NL_AFTER_PREPROC     (line:   4, col:   1):	Preprocessor statement must be followed by a newline
+Error: NL_AFTER_PREPROC     (line:   6, col:   1):	Preprocessor statement must be followed by a newline

--- a/tests/rules/samples/ok_include.out
+++ b/tests/rules/samples/ok_include.out
@@ -7,4 +7,4 @@
 [36mok_include.c[0m - [32mIsPreprocessorStatement[0m In "GlobalScope" from "None" line 4":
 		<HASH> <IDENTIFIER=include> <SPACE> <LESS_THAN> <IDENTIFIER=main> <DOT> <IDENTIFIER=h> <MORE_THAN> 
 ok_include.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header

--- a/tests/rules/samples/ok_pointer.out
+++ b/tests/rules/samples/ok_pointer.out
@@ -13,4 +13,4 @@
 [36mok_pointer.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 7":
 		<RBRACE> <NEWLINE>
 ok_pointer.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header

--- a/tests/rules/samples/ok_preproc_define.out
+++ b/tests/rules/samples/ok_preproc_define.out
@@ -5,4 +5,4 @@
 [36mok_preproc_define.c[0m - [32mIsPreprocessorStatement[0m In "GlobalScope" from "None" line 3":
 		<HASH> <IDENTIFIER=define> <SPACE> <IDENTIFIER=TOTO> <SPACE> <CONSTANT=12> <NEWLINE>
 ok_preproc_define.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header

--- a/tests/rules/samples/ok_preproc_indent.out
+++ b/tests/rules/samples/ok_preproc_indent.out
@@ -13,4 +13,4 @@
 [36mok_preproc_indent.c[0m - [32mIsPreprocessorStatement[0m In "GlobalScope" from "None" line 7":
 		<HASH> <IDENTIFIER=endif> <NEWLINE>
 ok_preproc_indent.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header

--- a/tests/rules/samples/ok_protection.out
+++ b/tests/rules/samples/ok_protection.out
@@ -17,5 +17,5 @@
 [36mok_protection.h[0m - [32mIsPreprocessorStatement[0m In "GlobalScope" from "None" line 9":
 		<HASH> <IDENTIFIER=endif> <NEWLINE>
 ok_protection.h: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
 Notice: GLOBAL_VAR_DETECTED  (line:   6, col:   1):	Global variable present in file. Make sure it is a reasonable choice.

--- a/tests/rules/samples/ok_struct_data.out
+++ b/tests/rules/samples/ok_struct_data.out
@@ -21,4 +21,4 @@
 [36mok_struct_data.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 11":
 		<RBRACE> <NEWLINE>
 ok_struct_data.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header

--- a/tests/rules/samples/ok_struct_name.out
+++ b/tests/rules/samples/ok_struct_name.out
@@ -35,8 +35,8 @@
 [36mok_struct_name.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 18":
 		<RBRACE> <NEWLINE>
 ok_struct_name.c: Error!
-Error: FORBIDDEN_TYPEDEF    (line:   1, col:   1):	[0mTypedef declaration are not allowed in .c files[0m
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: FORBIDDEN_STRUCT     (line:   5, col:   1):	[0mStruct declaration are not allowed in .c files[0m
+Error: FORBIDDEN_TYPEDEF    (line:   1, col:   1):	Typedef declaration are not allowed in .c files
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: FORBIDDEN_STRUCT     (line:   5, col:   1):	Struct declaration are not allowed in .c files
 Notice: GLOBAL_VAR_DETECTED  (line:  11, col:   1):	Global variable present in file. Make sure it is a reasonable choice.
 Notice: GLOBAL_VAR_DETECTED  (line:  12, col:   1):	Global variable present in file. Make sure it is a reasonable choice.

--- a/tests/rules/samples/ok_typedef.out
+++ b/tests/rules/samples/ok_typedef.out
@@ -33,7 +33,7 @@
 [36mok_typedef.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 17":
 		<RBRACE> <NEWLINE>
 ok_typedef.c: Error!
-Error: FORBIDDEN_TYPEDEF    (line:   1, col:   1):	[0mTypedef declaration are not allowed in .c files[0m
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: FORBIDDEN_TYPEDEF    (line:   7, col:   1):	[0mTypedef declaration are not allowed in .c files[0m
-Error: FORBIDDEN_STRUCT     (line:   9, col:   1):	[0mStruct declaration are not allowed in .c files[0m
+Error: FORBIDDEN_TYPEDEF    (line:   1, col:   1):	Typedef declaration are not allowed in .c files
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: FORBIDDEN_TYPEDEF    (line:   7, col:   1):	Typedef declaration are not allowed in .c files
+Error: FORBIDDEN_STRUCT     (line:   9, col:   1):	Struct declaration are not allowed in .c files

--- a/tests/rules/samples/ok_var_decl.out
+++ b/tests/rules/samples/ok_var_decl.out
@@ -41,4 +41,4 @@
 [36mok_var_decl.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 21":
 		<RBRACE> <NEWLINE>
 ok_var_decl.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header

--- a/tests/rules/samples/ok_var_name.out
+++ b/tests/rules/samples/ok_var_name.out
@@ -87,4 +87,4 @@
 [36mok_var_name.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 44":
 		<RBRACE> <NEWLINE>
 ok_var_name.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header

--- a/tests/rules/samples/test_comment_escaping_with_backslash.out
+++ b/tests/rules/samples/test_comment_escaping_with_backslash.out
@@ -21,17 +21,17 @@
 [36mtest_comment_escaping_with_backslash.c[0m - [32mIsComment[0m In "GlobalScope" from "None" line 11":
 		<MULT_COMMENT=/**/> 
 test_comment_escaping_with_backslash.c: Error!
-Error: INVALID_HEADER       (line:   3, col:   1):	[97mMissing or invalid 42 header[0m
-Error: SPACE_BEFORE_FUNC    (line:   6, col:   4):	[94mspace before function name[0m
-Error: NO_ARGS_VOID         (line:   6, col:  10):	[0mEmpty function argument requires void[0m
-Error: BRACE_NEWLINE        (line:   6, col:  12):	[93mExpected newline before brace[0m
-Error: TOO_FEW_TAB          (line:   7, col:   1):	[0mMissing tabs for indent level[0m
-Error: FORBIDDEN_CS         (line:   7, col:   3):	[0mForbidden control structure[0m
-Error: SPACE_REPLACE_TAB    (line:   7, col:   3):	[0mFound space when expecting tab[0m
-Error: SPC_AFTER_OPERATOR   (line:   7, col:  13):	[94mmissing space after operator[0m
-Error: SPC_BFR_OPERATOR     (line:   7, col:  13):	[94mmissing space before operator[0m
-Error: SPC_AFTER_OPERATOR   (line:   7, col:  18):	[94mmissing space after operator[0m
-Error: SPC_BFR_OPERATOR     (line:   7, col:  18):	[94mmissing space before operator[0m
-Error: SPC_AFTER_OPERATOR   (line:   7, col:  20):	[94mmissing space after operator[0m
-Error: TOO_FEW_TAB          (line:   8, col:   1):	[0mMissing tabs for indent level[0m
-Error: SPACE_REPLACE_TAB    (line:   8, col:   5):	[0mFound space when expecting tab[0m
+Error: INVALID_HEADER       (line:   3, col:   1):	Missing or invalid 42 header
+Error: SPACE_BEFORE_FUNC    (line:   6, col:   4):	space before function name
+Error: NO_ARGS_VOID         (line:   6, col:  10):	Empty function argument requires void
+Error: BRACE_NEWLINE        (line:   6, col:  12):	Expected newline before brace
+Error: TOO_FEW_TAB          (line:   7, col:   1):	Missing tabs for indent level
+Error: FORBIDDEN_CS         (line:   7, col:   3):	Forbidden control structure
+Error: SPACE_REPLACE_TAB    (line:   7, col:   3):	Found space when expecting tab
+Error: SPC_AFTER_OPERATOR   (line:   7, col:  13):	missing space after operator
+Error: SPC_BFR_OPERATOR     (line:   7, col:  13):	missing space before operator
+Error: SPC_AFTER_OPERATOR   (line:   7, col:  18):	missing space after operator
+Error: SPC_BFR_OPERATOR     (line:   7, col:  18):	missing space before operator
+Error: SPC_AFTER_OPERATOR   (line:   7, col:  20):	missing space after operator
+Error: TOO_FEW_TAB          (line:   8, col:   1):	Missing tabs for indent level
+Error: SPACE_REPLACE_TAB    (line:   8, col:   5):	Found space when expecting tab

--- a/tests/rules/samples/test_comment_escaping_with_trigraph.out
+++ b/tests/rules/samples/test_comment_escaping_with_trigraph.out
@@ -21,17 +21,17 @@
 [36mtest_comment_escaping_with_trigraph.c[0m - [32mIsComment[0m In "GlobalScope" from "None" line 11":
 		<MULT_COMMENT=/**/> 
 test_comment_escaping_with_trigraph.c: Error!
-Error: INVALID_HEADER       (line:   3, col:   1):	[97mMissing or invalid 42 header[0m
-Error: SPACE_BEFORE_FUNC    (line:   6, col:   4):	[94mspace before function name[0m
-Error: NO_ARGS_VOID         (line:   6, col:  10):	[0mEmpty function argument requires void[0m
-Error: BRACE_NEWLINE        (line:   6, col:  12):	[93mExpected newline before brace[0m
-Error: TOO_FEW_TAB          (line:   7, col:   1):	[0mMissing tabs for indent level[0m
-Error: FORBIDDEN_CS         (line:   7, col:   3):	[0mForbidden control structure[0m
-Error: SPACE_REPLACE_TAB    (line:   7, col:   3):	[0mFound space when expecting tab[0m
-Error: SPC_AFTER_OPERATOR   (line:   7, col:  13):	[94mmissing space after operator[0m
-Error: SPC_BFR_OPERATOR     (line:   7, col:  13):	[94mmissing space before operator[0m
-Error: SPC_AFTER_OPERATOR   (line:   7, col:  18):	[94mmissing space after operator[0m
-Error: SPC_BFR_OPERATOR     (line:   7, col:  18):	[94mmissing space before operator[0m
-Error: SPC_AFTER_OPERATOR   (line:   7, col:  20):	[94mmissing space after operator[0m
-Error: TOO_FEW_TAB          (line:   8, col:   1):	[0mMissing tabs for indent level[0m
-Error: SPACE_REPLACE_TAB    (line:   8, col:   5):	[0mFound space when expecting tab[0m
+Error: INVALID_HEADER       (line:   3, col:   1):	Missing or invalid 42 header
+Error: SPACE_BEFORE_FUNC    (line:   6, col:   4):	space before function name
+Error: NO_ARGS_VOID         (line:   6, col:  10):	Empty function argument requires void
+Error: BRACE_NEWLINE        (line:   6, col:  12):	Expected newline before brace
+Error: TOO_FEW_TAB          (line:   7, col:   1):	Missing tabs for indent level
+Error: FORBIDDEN_CS         (line:   7, col:   3):	Forbidden control structure
+Error: SPACE_REPLACE_TAB    (line:   7, col:   3):	Found space when expecting tab
+Error: SPC_AFTER_OPERATOR   (line:   7, col:  13):	missing space after operator
+Error: SPC_BFR_OPERATOR     (line:   7, col:  13):	missing space before operator
+Error: SPC_AFTER_OPERATOR   (line:   7, col:  18):	missing space after operator
+Error: SPC_BFR_OPERATOR     (line:   7, col:  18):	missing space before operator
+Error: SPC_AFTER_OPERATOR   (line:   7, col:  20):	missing space after operator
+Error: TOO_FEW_TAB          (line:   8, col:   1):	Missing tabs for indent level
+Error: SPACE_REPLACE_TAB    (line:   8, col:   5):	Found space when expecting tab

--- a/tests/rules/samples/test_comments.out
+++ b/tests/rules/samples/test_comments.out
@@ -47,32 +47,32 @@
 [36mtest_comments.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 21":
 		<RBRACE> <NEWLINE>
 test_comments.c: Error!
-Error: FORBIDDEN_STRUCT     (line:   1, col:   1):	[0mStruct declaration are not allowed in .c files[0m
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: BRACE_NEWLINE        (line:   1, col:   8):	[93mExpected newline before brace[0m
-Error: FORBIDDEN_TYPEDEF    (line:   6, col:   1):	[0mTypedef declaration are not allowed in .c files[0m
-Error: COMMENT_ON_INSTR     (line:   6, col:   9):	[95mComment must be on its own line or at end of a line[0m
-Error: SPACE_REPLACE_TAB    (line:   6, col:  25):	[0mFound space when expecting tab[0m
-Error: USER_DEFINED_TYPEDEF (line:   6, col:  26):	[0mUser defined typedef must start with t_[0m
-Error: FORBIDDEN_ENUM       (line:   8, col:   1):	[0mEnum declaration are not allowed in .c files[0m
-Error: ENUM_TYPE_NAMING     (line:   8, col:   6):	[0mEnum name must start with e_[0m
-Error: BRACE_NEWLINE        (line:   8, col:  11):	[93mExpected newline before brace[0m
-Error: SPACE_EMPTY_LINE     (line:   9, col:   5):	[0mSpace on empty line[0m
-Error: TOO_FEW_TAB          (line:  10, col:   1):	[0mMissing tabs for indent level[0m
-Error: SPACE_REPLACE_TAB    (line:  10, col:   5):	[0mFound space when expecting tab[0m
-Error: CONSECUTIVE_SPC      (line:  10, col:  11):	[94mTwo or more consecutives spaces[0m
-Error: SPACE_REPLACE_TAB    (line:  11, col:   5):	[0mFound space when expecting tab[0m
-Error: TOO_FEW_TAB          (line:  11, col:  16):	[0mMissing tabs for indent level[0m
-Error: SPACE_BEFORE_FUNC    (line:  14, col:   5):	[94mspace before function name[0m
-Error: COMMENT_ON_INSTR     (line:  14, col:  12):	[95mComment must be on its own line or at end of a line[0m
-Error: MISSING_IDENTIFIER   (line:  14, col:  25):	[0mmissing type qualifier or identifier in function arguments[0m
-Error: SPACE_EMPTY_LINE     (line:  16, col:   4):	[0mSpace on empty line[0m
-Error: WRONG_SCOPE_COMMENT  (line:  16, col:   4):	[95mComment is invalid in this scope[0m
-Error: TOO_FEW_TAB          (line:  17, col:   1):	[0mMissing tabs for indent level[0m
-Error: SPACE_EMPTY_LINE     (line:  17, col:   4):	[0mSpace on empty line[0m
-Error: SPACE_EMPTY_LINE     (line:  18, col:   7):	[0mSpace on empty line[0m
-Error: WRONG_SCOPE_COMMENT  (line:  18, col:   7):	[95mComment is invalid in this scope[0m
-Error: SPACE_EMPTY_LINE     (line:  19, col:   7):	[0mSpace on empty line[0m
-Error: WRONG_SCOPE_COMMENT  (line:  19, col:   7):	[95mComment is invalid in this scope[0m
-Error: TOO_FEW_TAB          (line:  20, col:   1):	[0mMissing tabs for indent level[0m
-Error: SPACE_EMPTY_LINE     (line:  20, col:   4):	[0mSpace on empty line[0m
+Error: FORBIDDEN_STRUCT     (line:   1, col:   1):	Struct declaration are not allowed in .c files
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: BRACE_NEWLINE        (line:   1, col:   8):	Expected newline before brace
+Error: FORBIDDEN_TYPEDEF    (line:   6, col:   1):	Typedef declaration are not allowed in .c files
+Error: COMMENT_ON_INSTR     (line:   6, col:   9):	Comment must be on its own line or at end of a line
+Error: SPACE_REPLACE_TAB    (line:   6, col:  25):	Found space when expecting tab
+Error: USER_DEFINED_TYPEDEF (line:   6, col:  26):	User defined typedef must start with t_
+Error: FORBIDDEN_ENUM       (line:   8, col:   1):	Enum declaration are not allowed in .c files
+Error: ENUM_TYPE_NAMING     (line:   8, col:   6):	Enum name must start with e_
+Error: BRACE_NEWLINE        (line:   8, col:  11):	Expected newline before brace
+Error: SPACE_EMPTY_LINE     (line:   9, col:   5):	Space on empty line
+Error: TOO_FEW_TAB          (line:  10, col:   1):	Missing tabs for indent level
+Error: SPACE_REPLACE_TAB    (line:  10, col:   5):	Found space when expecting tab
+Error: CONSECUTIVE_SPC      (line:  10, col:  11):	Two or more consecutives spaces
+Error: SPACE_REPLACE_TAB    (line:  11, col:   5):	Found space when expecting tab
+Error: TOO_FEW_TAB          (line:  11, col:  16):	Missing tabs for indent level
+Error: SPACE_BEFORE_FUNC    (line:  14, col:   5):	space before function name
+Error: COMMENT_ON_INSTR     (line:  14, col:  12):	Comment must be on its own line or at end of a line
+Error: MISSING_IDENTIFIER   (line:  14, col:  25):	missing type qualifier or identifier in function arguments
+Error: SPACE_EMPTY_LINE     (line:  16, col:   4):	Space on empty line
+Error: WRONG_SCOPE_COMMENT  (line:  16, col:   4):	Comment is invalid in this scope
+Error: TOO_FEW_TAB          (line:  17, col:   1):	Missing tabs for indent level
+Error: SPACE_EMPTY_LINE     (line:  17, col:   4):	Space on empty line
+Error: SPACE_EMPTY_LINE     (line:  18, col:   7):	Space on empty line
+Error: WRONG_SCOPE_COMMENT  (line:  18, col:   7):	Comment is invalid in this scope
+Error: SPACE_EMPTY_LINE     (line:  19, col:   7):	Space on empty line
+Error: WRONG_SCOPE_COMMENT  (line:  19, col:   7):	Comment is invalid in this scope
+Error: TOO_FEW_TAB          (line:  20, col:   1):	Missing tabs for indent level
+Error: SPACE_EMPTY_LINE     (line:  20, col:   4):	Space on empty line

--- a/tests/rules/samples/test_file_0907.out
+++ b/tests/rules/samples/test_file_0907.out
@@ -1,5 +1,5 @@
 [36mtest_file_0907.c[0m - [32mIsFuncPrototype[0m In "GlobalScope" from "None" line 1":
 		<INT> <TAB> <IDENTIFIER=room_indexcmp> <LPARENTHESIS> <IDENTIFIER=t_room> <SPACE> <MULT> <IDENTIFIER=room1> <COMMA> <SPACE> <UNSIGNED> <SPACE> <MULT> <IDENTIFIER=index2> <RPARENTHESIS> <SEMI_COLON> 
 test_file_0907.c: Error!
-Error: ARG_TYPE_UKN         (line:   1, col:   1):	[0mUnrecognized variable type[0m
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
+Error: ARG_TYPE_UKN         (line:   1, col:   1):	Unrecognized variable type
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header

--- a/tests/rules/samples/test_file_0907_2.out
+++ b/tests/rules/samples/test_file_0907_2.out
@@ -229,4 +229,4 @@
 [36mtest_file_0907_2.h[0m - [32mIsPreprocessorStatement[0m In "GlobalScope" from "None" line 143":
 		<HASH> <IDENTIFIER=endif> <NEWLINE>
 test_file_0907_2.h: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header

--- a/tests/rules/samples/test_file_0907_3.out
+++ b/tests/rules/samples/test_file_0907_3.out
@@ -423,129 +423,129 @@
 [36mtest_file_0907_3.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 201":
 		<RBRACE> 
 test_file_0907_3.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: TOO_MANY_TABS_FUNC   (line:   1, col:   5):	[94mextra tabs before function name[0m
-Error: MIXED_SPACE_TAB      (line:   4, col:  19):	[93mMixed spaces and tabs[0m
-Error: SPACE_REPLACE_TAB    (line:   4, col:  19):	[0mFound space when expecting tab[0m
-Error: MULT_DECL_LINE       (line:   4, col:  24):	[0mMultiple declarations on a single line[0m
-Error: MULT_DECL_LINE       (line:   6, col:  23):	[0mMultiple declarations on a single line[0m
-Error: MULT_DECL_LINE       (line:   7, col:  25):	[0mMultiple declarations on a single line[0m
-Error: TOO_MANY_VARS_FUNC   (line:   8, col:   1):	[91mToo many variables declarations in a function[0m
-Error: TOO_MANY_VARS_FUNC   (line:   9, col:   1):	[91mToo many variables declarations in a function[0m
-Error: TOO_MANY_VARS_FUNC   (line:  10, col:   1):	[91mToo many variables declarations in a function[0m
-Error: TOO_MANY_VARS_FUNC   (line:  11, col:   1):	[91mToo many variables declarations in a function[0m
-Error: MULT_DECL_LINE       (line:  11, col:  25):	[0mMultiple declarations on a single line[0m
-Error: FORBIDDEN_CHAR_NAME  (line:  11, col:  27):	[0muser defined identifiers should contain only lowercase characters, digits or '_'[0m
-Error: MULT_DECL_LINE       (line:  11, col:  31):	[0mMultiple declarations on a single line[0m
-Error: MULT_DECL_LINE       (line:  11, col:  37):	[0mMultiple declarations on a single line[0m
-Error: MULT_DECL_LINE       (line:  11, col:  43):	[0mMultiple declarations on a single line[0m
-Error: MULT_DECL_LINE       (line:  11, col:  47):	[0mMultiple declarations on a single line[0m
-Error: MULT_DECL_LINE       (line:  11, col:  50):	[0mMultiple declarations on a single line[0m
-Error: TOO_MANY_VARS_FUNC   (line:  12, col:   1):	[91mToo many variables declarations in a function[0m
-Error: MULT_DECL_LINE       (line:  12, col:  30):	[0mMultiple declarations on a single line[0m
-Error: TOO_MANY_VARS_FUNC   (line:  13, col:   1):	[91mToo many variables declarations in a function[0m
-Error: MULT_DECL_LINE       (line:  13, col:  26):	[0mMultiple declarations on a single line[0m
-Error: MULT_ASSIGN_LINE     (line:  15, col:  17):	[0mMultiple assignations on a single line[0m
-Error: MULT_ASSIGN_LINE     (line:  15, col:  24):	[0mMultiple assignations on a single line[0m
-Error: MULT_ASSIGN_LINE     (line:  15, col:  31):	[0mMultiple assignations on a single line[0m
-Error: TAB_INSTEAD_SPC      (line:  19, col:  16):	[94mFound tab when expecting space[0m
-Error: WRONG_SCOPE_COMMENT  (line:  19, col:  17):	[95mComment is invalid in this scope[0m
-Error: WRONG_SCOPE_COMMENT  (line:  19, col:  17):	[95mComment is invalid in this scope[0m
-Error: EMPTY_LINE_FUNCTION  (line:  22, col:   1):	[0mEmpty line in function[0m
-Error: ASSIGN_IN_CONTROL    (line:  23, col:  16):	[0mAssignment in control structure[0m
-Error: FORBIDDEN_CS         (line:  24, col:   9):	[0mForbidden control structure[0m
-Error: SPACE_AFTER_KW       (line:  24, col:   9):	[0mMissing space after keyword[0m
-Error: SPC_BFR_PAR          (line:  24, col:  15):	[94mMissing space before parenthesis (brace/bracket)[0m
-Error: NO_SPC_AFR_PAR       (line:  24, col:  18):	[94mExtra space after parenthesis (brace/bracket)[0m
-Error: MULT_IN_SINGLE_INSTR (line:  24, col:  20):	[0mMultiple instructions in single line control structure[0m
-Error: TOO_FEW_TAB          (line:  24, col:  20):	[0mMissing tabs for indent level[0m
-Error: FORBIDDEN_CS         (line:  25, col:  13):	[0mForbidden control structure[0m
-Error: TOO_MANY_TAB         (line:  27, col:   1):	[0mExtra tabs for indent level[0m
-Error: SPACE_AFTER_KW       (line:  27, col:  17):	[0mMissing space after keyword[0m
-Error: FORBIDDEN_CS         (line:  28, col:  13):	[0mForbidden control structure[0m
-Error: TOO_MANY_TAB         (line:  30, col:   1):	[0mExtra tabs for indent level[0m
-Error: SPACE_AFTER_KW       (line:  30, col:  17):	[0mMissing space after keyword[0m
-Error: FORBIDDEN_CS         (line:  31, col:  13):	[0mForbidden control structure[0m
-Error: TOO_MANY_TAB         (line:  33, col:   1):	[0mExtra tabs for indent level[0m
-Error: SPACE_AFTER_KW       (line:  33, col:  17):	[0mMissing space after keyword[0m
-Error: FORBIDDEN_CS         (line:  34, col:  13):	[0mForbidden control structure[0m
-Error: TOO_MANY_TAB         (line:  36, col:   1):	[0mExtra tabs for indent level[0m
-Error: SPACE_AFTER_KW       (line:  36, col:  17):	[0mMissing space after keyword[0m
-Error: FORBIDDEN_CS         (line:  37, col:  13):	[0mForbidden control structure[0m
-Error: TOO_MANY_TAB         (line:  39, col:   1):	[0mExtra tabs for indent level[0m
-Error: SPACE_AFTER_KW       (line:  39, col:  17):	[0mMissing space after keyword[0m
-Error: FORBIDDEN_CS         (line:  40, col:  13):	[0mForbidden control structure[0m
-Error: TOO_MANY_TAB         (line:  42, col:   1):	[0mExtra tabs for indent level[0m
-Error: SPACE_AFTER_KW       (line:  42, col:  17):	[0mMissing space after keyword[0m
-Error: FORBIDDEN_CS         (line:  43, col:  13):	[0mForbidden control structure[0m
-Error: TOO_MANY_TAB         (line:  45, col:   1):	[0mExtra tabs for indent level[0m
-Error: SPACE_AFTER_KW       (line:  45, col:  17):	[0mMissing space after keyword[0m
-Error: FORBIDDEN_CS         (line:  46, col:  13):	[0mForbidden control structure[0m
-Error: TOO_MANY_TAB         (line:  48, col:   1):	[0mExtra tabs for indent level[0m
-Error: TOO_MANY_TAB         (line:  49, col:   1):	[0mExtra tabs for indent level[0m
-Error: TOO_MANY_TAB         (line:  50, col:   1):	[0mExtra tabs for indent level[0m
-Error: SPACE_AFTER_KW       (line:  50, col:  17):	[0mMissing space after keyword[0m
-Error: FORBIDDEN_CS         (line:  51, col:  13):	[0mForbidden control structure[0m
-Error: TOO_FEW_TAB          (line:  52, col:   1):	[0mMissing tabs for indent level[0m
-Error: SPACE_AFTER_KW       (line:  52, col:  13):	[0mMissing space after keyword[0m
-Error: TOO_FEW_TAB          (line:  53, col:   1):	[0mMissing tabs for indent level[0m
-Error: EMPTY_LINE_FUNCTION  (line:  57, col:   1):	[0mEmpty line in function[0m
-Error: BRACE_SHOULD_EOL     (line:  63, col:   6):	[0mExpected newline after brace[0m
-Error: TOO_FEW_TAB          (line:  63, col:   7):	[0mMissing tabs for indent level[0m
-Error: TOO_MANY_INSTR       (line:  63, col:   7):	[0mToo many instructions on a single line[0m
-Error: TOO_MANY_VARS_FUNC   (line:  65, col:   1):	[91mToo many variables declarations in a function[0m
-Error: VAR_DECL_START_FUNC  (line:  65, col:   1):	[0mVariable declaration not at start of function[0m
-Error: MISALIGNED_VAR_DECL  (line:  65, col:  13):	[0mMisaligned variable declaration[0m
-Error: DECL_ASSIGN_LINE     (line:  65, col:  20):	[0mDeclaration and assignation on a single line[0m
-Error: TERNARY_FBIDDEN      (line:  65, col:  27):	[0mTernaries are forbidden[0m
-Error: TERNARY_FBIDDEN      (line:  65, col:  45):	[0mTernaries are forbidden[0m
-Error: SPC_AFTER_OPERATOR   (line:  65, col:  54):	[94mmissing space after operator[0m
-Error: SPC_BFR_OPERATOR     (line:  65, col:  54):	[94mmissing space before operator[0m
-Error: SPC_AFTER_OPERATOR   (line:  65, col:  61):	[94mmissing space after operator[0m
-Error: SPC_BFR_OPERATOR     (line:  65, col:  61):	[94mmissing space before operator[0m
-Error: SPC_AFTER_OPERATOR   (line:  65, col:  80):	[94mmissing space after operator[0m
-Error: SPC_BFR_OPERATOR     (line:  65, col:  80):	[94mmissing space before operator[0m
-Error: LINE_TOO_LONG        (line:  65, col:  87):	[94mline too long[0m
-Error: SPC_AFTER_OPERATOR   (line:  65, col:  87):	[94mmissing space after operator[0m
-Error: SPC_BFR_OPERATOR     (line:  65, col:  87):	[94mmissing space before operator[0m
-Error: ASSIGN_IN_CONTROL    (line:  66, col:  19):	[0mAssignment in control structure[0m
-Error: EMPTY_LINE_FUNCTION  (line:  68, col:   1):	[0mEmpty line in function[0m
-Error: WRONG_SCOPE_COMMENT  (line:  69, col:   5):	[95mComment is invalid in this scope[0m
-Error: EMPTY_LINE_FUNCTION  (line:  71, col:   1):	[0mEmpty line in function[0m
-Error: ASSIGN_IN_CONTROL    (line:  72, col:  17):	[0mAssignment in control structure[0m
-Error: NO_SPC_AFR_PAR       (line:  72, col:  49):	[94mExtra space after parenthesis (brace/bracket)[0m
-Error: TOO_FEW_TAB          (line:  72, col:  51):	[0mMissing tabs for indent level[0m
-Error: BRACE_SHOULD_EOL     (line:  79, col:   6):	[0mExpected newline after brace[0m
-Error: TOO_FEW_TAB          (line:  79, col:   7):	[0mMissing tabs for indent level[0m
-Error: TOO_MANY_INSTR       (line:  79, col:   7):	[0mToo many instructions on a single line[0m
-Error: TOO_FEW_TAB          (line:  79, col:  12):	[0mMissing tabs for indent level[0m
-Error: EMPTY_LINE_FUNCTION  (line:  83, col:   1):	[0mEmpty line in function[0m
-Error: EMPTY_LINE_FUNCTION  (line:  86, col:   1):	[0mEmpty line in function[0m
-Error: WRONG_SCOPE_COMMENT  (line:  92, col:   9):	[95mComment is invalid in this scope[0m
-Error: NO_SPC_AFR_PAR       (line:  93, col:  20):	[94mExtra space after parenthesis (brace/bracket)[0m
-Error: TOO_FEW_TAB          (line:  93, col:  22):	[0mMissing tabs for indent level[0m
-Error: WRONG_SCOPE_COMMENT  (line:  96, col:  13):	[95mComment is invalid in this scope[0m
-Error: NO_SPC_AFR_PAR       (line:  97, col:  24):	[94mExtra space after parenthesis (brace/bracket)[0m
-Error: TOO_FEW_TAB          (line:  97, col:  26):	[0mMissing tabs for indent level[0m
-Error: FORBIDDEN_CS         (line: 100, col:  17):	[0mForbidden control structure[0m
-Error: NO_SPC_BFR_OPR       (line: 100, col:  28):	[94mextra space before operator[0m
-Error: NO_SPC_AFR_PAR       (line: 100, col:  36):	[94mExtra space after parenthesis (brace/bracket)[0m
-Error: NO_SPC_BFR_OPR       (line: 100, col:  38):	[94mextra space before operator[0m
-Error: NO_SPC_AFR_PAR       (line: 100, col:  43):	[94mExtra space after parenthesis (brace/bracket)[0m
-Error: TOO_FEW_TAB          (line: 100, col:  45):	[0mMissing tabs for indent level[0m
-Error: EMPTY_LINE_FUNCTION  (line: 116, col:   1):	[0mEmpty line in function[0m
-Error: NO_SPC_AFR_PAR       (line: 118, col:  18):	[94mExtra space after parenthesis (brace/bracket)[0m
-Error: TOO_FEW_TAB          (line: 118, col:  20):	[0mMissing tabs for indent level[0m
-Error: EMPTY_LINE_FUNCTION  (line: 127, col:   1):	[0mEmpty line in function[0m
-Error: MULT_ASSIGN_LINE     (line: 128, col:  18):	[0mMultiple assignations on a single line[0m
-Error: SPACE_AFTER_KW       (line: 155, col:  13):	[0mMissing space after keyword[0m
-Error: NO_SPC_AFR_PAR       (line: 156, col:  50):	[94mExtra space after parenthesis (brace/bracket)[0m
-Error: TOO_FEW_TAB          (line: 156, col:  52):	[0mMissing tabs for indent level[0m
-Error: SPACE_AFTER_KW       (line: 159, col:  17):	[0mMissing space after keyword[0m
-Error: LINE_TOO_LONG        (line: 162, col:  86):	[94mline too long[0m
-Error: NO_SPC_AFR_PAR       (line: 168, col:  23):	[94mExtra space after parenthesis (brace/bracket)[0m
-Error: TOO_FEW_TAB          (line: 168, col:  25):	[0mMissing tabs for indent level[0m
-Error: LINE_TOO_LONG        (line: 172, col:  86):	[94mline too long[0m
-Error: SPACE_AFTER_KW       (line: 182, col:  17):	[0mMissing space after keyword[0m
-Error: BRACE_SHOULD_EOL     (line: 201, col:   1):	[0mExpected newline after brace[0m
-Error: TOO_MANY_LINES       (line: 201, col:   1):	[0mFunction has more than 25 lines[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: TOO_MANY_TABS_FUNC   (line:   1, col:   5):	extra tabs before function name
+Error: MIXED_SPACE_TAB      (line:   4, col:  19):	Mixed spaces and tabs
+Error: SPACE_REPLACE_TAB    (line:   4, col:  19):	Found space when expecting tab
+Error: MULT_DECL_LINE       (line:   4, col:  24):	Multiple declarations on a single line
+Error: MULT_DECL_LINE       (line:   6, col:  23):	Multiple declarations on a single line
+Error: MULT_DECL_LINE       (line:   7, col:  25):	Multiple declarations on a single line
+Error: TOO_MANY_VARS_FUNC   (line:   8, col:   1):	Too many variables declarations in a function
+Error: TOO_MANY_VARS_FUNC   (line:   9, col:   1):	Too many variables declarations in a function
+Error: TOO_MANY_VARS_FUNC   (line:  10, col:   1):	Too many variables declarations in a function
+Error: TOO_MANY_VARS_FUNC   (line:  11, col:   1):	Too many variables declarations in a function
+Error: MULT_DECL_LINE       (line:  11, col:  25):	Multiple declarations on a single line
+Error: FORBIDDEN_CHAR_NAME  (line:  11, col:  27):	user defined identifiers should contain only lowercase characters, digits or '_'
+Error: MULT_DECL_LINE       (line:  11, col:  31):	Multiple declarations on a single line
+Error: MULT_DECL_LINE       (line:  11, col:  37):	Multiple declarations on a single line
+Error: MULT_DECL_LINE       (line:  11, col:  43):	Multiple declarations on a single line
+Error: MULT_DECL_LINE       (line:  11, col:  47):	Multiple declarations on a single line
+Error: MULT_DECL_LINE       (line:  11, col:  50):	Multiple declarations on a single line
+Error: TOO_MANY_VARS_FUNC   (line:  12, col:   1):	Too many variables declarations in a function
+Error: MULT_DECL_LINE       (line:  12, col:  30):	Multiple declarations on a single line
+Error: TOO_MANY_VARS_FUNC   (line:  13, col:   1):	Too many variables declarations in a function
+Error: MULT_DECL_LINE       (line:  13, col:  26):	Multiple declarations on a single line
+Error: MULT_ASSIGN_LINE     (line:  15, col:  17):	Multiple assignations on a single line
+Error: MULT_ASSIGN_LINE     (line:  15, col:  24):	Multiple assignations on a single line
+Error: MULT_ASSIGN_LINE     (line:  15, col:  31):	Multiple assignations on a single line
+Error: TAB_INSTEAD_SPC      (line:  19, col:  16):	Found tab when expecting space
+Error: WRONG_SCOPE_COMMENT  (line:  19, col:  17):	Comment is invalid in this scope
+Error: WRONG_SCOPE_COMMENT  (line:  19, col:  17):	Comment is invalid in this scope
+Error: EMPTY_LINE_FUNCTION  (line:  22, col:   1):	Empty line in function
+Error: ASSIGN_IN_CONTROL    (line:  23, col:  16):	Assignment in control structure
+Error: FORBIDDEN_CS         (line:  24, col:   9):	Forbidden control structure
+Error: SPACE_AFTER_KW       (line:  24, col:   9):	Missing space after keyword
+Error: SPC_BFR_PAR          (line:  24, col:  15):	Missing space before parenthesis (brace/bracket)
+Error: NO_SPC_AFR_PAR       (line:  24, col:  18):	Extra space after parenthesis (brace/bracket)
+Error: MULT_IN_SINGLE_INSTR (line:  24, col:  20):	Multiple instructions in single line control structure
+Error: TOO_FEW_TAB          (line:  24, col:  20):	Missing tabs for indent level
+Error: FORBIDDEN_CS         (line:  25, col:  13):	Forbidden control structure
+Error: TOO_MANY_TAB         (line:  27, col:   1):	Extra tabs for indent level
+Error: SPACE_AFTER_KW       (line:  27, col:  17):	Missing space after keyword
+Error: FORBIDDEN_CS         (line:  28, col:  13):	Forbidden control structure
+Error: TOO_MANY_TAB         (line:  30, col:   1):	Extra tabs for indent level
+Error: SPACE_AFTER_KW       (line:  30, col:  17):	Missing space after keyword
+Error: FORBIDDEN_CS         (line:  31, col:  13):	Forbidden control structure
+Error: TOO_MANY_TAB         (line:  33, col:   1):	Extra tabs for indent level
+Error: SPACE_AFTER_KW       (line:  33, col:  17):	Missing space after keyword
+Error: FORBIDDEN_CS         (line:  34, col:  13):	Forbidden control structure
+Error: TOO_MANY_TAB         (line:  36, col:   1):	Extra tabs for indent level
+Error: SPACE_AFTER_KW       (line:  36, col:  17):	Missing space after keyword
+Error: FORBIDDEN_CS         (line:  37, col:  13):	Forbidden control structure
+Error: TOO_MANY_TAB         (line:  39, col:   1):	Extra tabs for indent level
+Error: SPACE_AFTER_KW       (line:  39, col:  17):	Missing space after keyword
+Error: FORBIDDEN_CS         (line:  40, col:  13):	Forbidden control structure
+Error: TOO_MANY_TAB         (line:  42, col:   1):	Extra tabs for indent level
+Error: SPACE_AFTER_KW       (line:  42, col:  17):	Missing space after keyword
+Error: FORBIDDEN_CS         (line:  43, col:  13):	Forbidden control structure
+Error: TOO_MANY_TAB         (line:  45, col:   1):	Extra tabs for indent level
+Error: SPACE_AFTER_KW       (line:  45, col:  17):	Missing space after keyword
+Error: FORBIDDEN_CS         (line:  46, col:  13):	Forbidden control structure
+Error: TOO_MANY_TAB         (line:  48, col:   1):	Extra tabs for indent level
+Error: TOO_MANY_TAB         (line:  49, col:   1):	Extra tabs for indent level
+Error: TOO_MANY_TAB         (line:  50, col:   1):	Extra tabs for indent level
+Error: SPACE_AFTER_KW       (line:  50, col:  17):	Missing space after keyword
+Error: FORBIDDEN_CS         (line:  51, col:  13):	Forbidden control structure
+Error: TOO_FEW_TAB          (line:  52, col:   1):	Missing tabs for indent level
+Error: SPACE_AFTER_KW       (line:  52, col:  13):	Missing space after keyword
+Error: TOO_FEW_TAB          (line:  53, col:   1):	Missing tabs for indent level
+Error: EMPTY_LINE_FUNCTION  (line:  57, col:   1):	Empty line in function
+Error: BRACE_SHOULD_EOL     (line:  63, col:   6):	Expected newline after brace
+Error: TOO_FEW_TAB          (line:  63, col:   7):	Missing tabs for indent level
+Error: TOO_MANY_INSTR       (line:  63, col:   7):	Too many instructions on a single line
+Error: TOO_MANY_VARS_FUNC   (line:  65, col:   1):	Too many variables declarations in a function
+Error: VAR_DECL_START_FUNC  (line:  65, col:   1):	Variable declaration not at start of function
+Error: MISALIGNED_VAR_DECL  (line:  65, col:  13):	Misaligned variable declaration
+Error: DECL_ASSIGN_LINE     (line:  65, col:  20):	Declaration and assignation on a single line
+Error: TERNARY_FBIDDEN      (line:  65, col:  27):	Ternaries are forbidden
+Error: TERNARY_FBIDDEN      (line:  65, col:  45):	Ternaries are forbidden
+Error: SPC_AFTER_OPERATOR   (line:  65, col:  54):	missing space after operator
+Error: SPC_BFR_OPERATOR     (line:  65, col:  54):	missing space before operator
+Error: SPC_AFTER_OPERATOR   (line:  65, col:  61):	missing space after operator
+Error: SPC_BFR_OPERATOR     (line:  65, col:  61):	missing space before operator
+Error: SPC_AFTER_OPERATOR   (line:  65, col:  80):	missing space after operator
+Error: SPC_BFR_OPERATOR     (line:  65, col:  80):	missing space before operator
+Error: LINE_TOO_LONG        (line:  65, col:  87):	line too long
+Error: SPC_AFTER_OPERATOR   (line:  65, col:  87):	missing space after operator
+Error: SPC_BFR_OPERATOR     (line:  65, col:  87):	missing space before operator
+Error: ASSIGN_IN_CONTROL    (line:  66, col:  19):	Assignment in control structure
+Error: EMPTY_LINE_FUNCTION  (line:  68, col:   1):	Empty line in function
+Error: WRONG_SCOPE_COMMENT  (line:  69, col:   5):	Comment is invalid in this scope
+Error: EMPTY_LINE_FUNCTION  (line:  71, col:   1):	Empty line in function
+Error: ASSIGN_IN_CONTROL    (line:  72, col:  17):	Assignment in control structure
+Error: NO_SPC_AFR_PAR       (line:  72, col:  49):	Extra space after parenthesis (brace/bracket)
+Error: TOO_FEW_TAB          (line:  72, col:  51):	Missing tabs for indent level
+Error: BRACE_SHOULD_EOL     (line:  79, col:   6):	Expected newline after brace
+Error: TOO_FEW_TAB          (line:  79, col:   7):	Missing tabs for indent level
+Error: TOO_MANY_INSTR       (line:  79, col:   7):	Too many instructions on a single line
+Error: TOO_FEW_TAB          (line:  79, col:  12):	Missing tabs for indent level
+Error: EMPTY_LINE_FUNCTION  (line:  83, col:   1):	Empty line in function
+Error: EMPTY_LINE_FUNCTION  (line:  86, col:   1):	Empty line in function
+Error: WRONG_SCOPE_COMMENT  (line:  92, col:   9):	Comment is invalid in this scope
+Error: NO_SPC_AFR_PAR       (line:  93, col:  20):	Extra space after parenthesis (brace/bracket)
+Error: TOO_FEW_TAB          (line:  93, col:  22):	Missing tabs for indent level
+Error: WRONG_SCOPE_COMMENT  (line:  96, col:  13):	Comment is invalid in this scope
+Error: NO_SPC_AFR_PAR       (line:  97, col:  24):	Extra space after parenthesis (brace/bracket)
+Error: TOO_FEW_TAB          (line:  97, col:  26):	Missing tabs for indent level
+Error: FORBIDDEN_CS         (line: 100, col:  17):	Forbidden control structure
+Error: NO_SPC_BFR_OPR       (line: 100, col:  28):	extra space before operator
+Error: NO_SPC_AFR_PAR       (line: 100, col:  36):	Extra space after parenthesis (brace/bracket)
+Error: NO_SPC_BFR_OPR       (line: 100, col:  38):	extra space before operator
+Error: NO_SPC_AFR_PAR       (line: 100, col:  43):	Extra space after parenthesis (brace/bracket)
+Error: TOO_FEW_TAB          (line: 100, col:  45):	Missing tabs for indent level
+Error: EMPTY_LINE_FUNCTION  (line: 116, col:   1):	Empty line in function
+Error: NO_SPC_AFR_PAR       (line: 118, col:  18):	Extra space after parenthesis (brace/bracket)
+Error: TOO_FEW_TAB          (line: 118, col:  20):	Missing tabs for indent level
+Error: EMPTY_LINE_FUNCTION  (line: 127, col:   1):	Empty line in function
+Error: MULT_ASSIGN_LINE     (line: 128, col:  18):	Multiple assignations on a single line
+Error: SPACE_AFTER_KW       (line: 155, col:  13):	Missing space after keyword
+Error: NO_SPC_AFR_PAR       (line: 156, col:  50):	Extra space after parenthesis (brace/bracket)
+Error: TOO_FEW_TAB          (line: 156, col:  52):	Missing tabs for indent level
+Error: SPACE_AFTER_KW       (line: 159, col:  17):	Missing space after keyword
+Error: LINE_TOO_LONG        (line: 162, col:  86):	line too long
+Error: NO_SPC_AFR_PAR       (line: 168, col:  23):	Extra space after parenthesis (brace/bracket)
+Error: TOO_FEW_TAB          (line: 168, col:  25):	Missing tabs for indent level
+Error: LINE_TOO_LONG        (line: 172, col:  86):	line too long
+Error: SPACE_AFTER_KW       (line: 182, col:  17):	Missing space after keyword
+Error: BRACE_SHOULD_EOL     (line: 201, col:   1):	Expected newline after brace
+Error: TOO_MANY_LINES       (line: 201, col:   1):	Function has more than 25 lines

--- a/tests/rules/samples/test_file_0907_4.out
+++ b/tests/rules/samples/test_file_0907_4.out
@@ -9,6 +9,6 @@
 [36mtest_file_0907_4.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 5":
 		<RBRACE> 
 test_file_0907_4.c: Error!
-Error: EMPTY_LINE_FILE_START (line:   1, col:   1):	[0mEmpty line at start of file[0m
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: BRACE_SHOULD_EOL     (line:   5, col:   1):	[0mExpected newline after brace[0m
+Error: EMPTY_LINE_FILE_START (line:   1, col:   1):	Empty line at start of file
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: BRACE_SHOULD_EOL     (line:   5, col:   1):	Expected newline after brace

--- a/tests/rules/samples/test_file_0924.out
+++ b/tests/rules/samples/test_file_0924.out
@@ -23,16 +23,16 @@
 [36mtest_file_0924.c[0m - [32mIsEmptyLine[0m In "GlobalScope" from "None" line 9":
 		<NEWLINE>
 test_file_0924.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: SPACE_BEFORE_FUNC    (line:   1, col:   5):	[94mspace before function name[0m
-Error: BRACE_NEWLINE        (line:   1, col:  47):	[93mExpected newline before brace[0m
-Error: TOO_MANY_TAB         (line:   5, col:   1):	[0mExtra tabs for indent level[0m
-Error: BRACE_SHOULD_EOL     (line:   5, col:  13):	[0mExpected newline after brace[0m
-Error: TOO_FEW_TAB          (line:   5, col:  14):	[0mMissing tabs for indent level[0m
-Error: TOO_MANY_INSTR       (line:   5, col:  14):	[0mToo many instructions on a single line[0m
-Error: ASSIGN_IN_CONTROL    (line:   5, col:  22):	[0mAssignment in control structure[0m
-Error: TOO_FEW_TAB          (line:   6, col:   1):	[0mMissing tabs for indent level[0m
-Error: NO_SPC_BFR_OPR       (line:   6, col:  20):	[94mextra space before operator[0m
-Error: TOO_FEW_TAB          (line:   6, col:  21):	[0mMissing tabs for indent level[0m
-Error: TOO_MANY_INSTR       (line:   6, col:  21):	[0mToo many instructions on a single line[0m
-Error: EMPTY_LINE_EOF       (line:   9, col:   1):	[0mEmpty line at end of file[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: SPACE_BEFORE_FUNC    (line:   1, col:   5):	space before function name
+Error: BRACE_NEWLINE        (line:   1, col:  47):	Expected newline before brace
+Error: TOO_MANY_TAB         (line:   5, col:   1):	Extra tabs for indent level
+Error: BRACE_SHOULD_EOL     (line:   5, col:  13):	Expected newline after brace
+Error: TOO_FEW_TAB          (line:   5, col:  14):	Missing tabs for indent level
+Error: TOO_MANY_INSTR       (line:   5, col:  14):	Too many instructions on a single line
+Error: ASSIGN_IN_CONTROL    (line:   5, col:  22):	Assignment in control structure
+Error: TOO_FEW_TAB          (line:   6, col:   1):	Missing tabs for indent level
+Error: NO_SPC_BFR_OPR       (line:   6, col:  20):	extra space before operator
+Error: TOO_FEW_TAB          (line:   6, col:  21):	Missing tabs for indent level
+Error: TOO_MANY_INSTR       (line:   6, col:  21):	Too many instructions on a single line
+Error: EMPTY_LINE_EOF       (line:   9, col:   1):	Empty line at end of file

--- a/tests/rules/samples/test_file_1012.out
+++ b/tests/rules/samples/test_file_1012.out
@@ -188,4 +188,4 @@
 [36mtest_file_1012.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 99":
 		<RBRACE> <NEWLINE>
 test_file_1012.c: Error!
-Error: SPACE_AFTER_KW       (line:  71, col:  15):	[0mMissing space after keyword[0m
+Error: SPACE_AFTER_KW       (line:  71, col:  15):	Missing space after keyword

--- a/tests/rules/samples/test_file_1012_2.out
+++ b/tests/rules/samples/test_file_1012_2.out
@@ -154,5 +154,5 @@
 [36mtest_file_1012_2.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 82":
 		<RBRACE> <NEWLINE>
 test_file_1012_2.c: Error!
-Error: TOO_FEW_TAB          (line:  47, col:   1):	[0mMissing tabs for indent level[0m
-Error: TOO_FEW_TAB          (line:  51, col:   1):	[0mMissing tabs for indent level[0m
+Error: TOO_FEW_TAB          (line:  47, col:   1):	Missing tabs for indent level
+Error: TOO_FEW_TAB          (line:  51, col:   1):	Missing tabs for indent level

--- a/tests/rules/samples/test_file_1012_4.out
+++ b/tests/rules/samples/test_file_1012_4.out
@@ -4,5 +4,5 @@
 		<IDENTIFIER=t_montype> <TAB> <IDENTIFIER=g_glob> <SEMI_COLON> 
 test_file_1012_4.c: Error!
 Notice: GLOBAL_VAR_DETECTED  (line:   1, col:   1):	Global variable present in file. Make sure it is a reasonable choice.
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
 Notice: GLOBAL_VAR_DETECTED  (line:   2, col:   1):	Global variable present in file. Make sure it is a reasonable choice.

--- a/tests/rules/samples/test_file_1019.out
+++ b/tests/rules/samples/test_file_1019.out
@@ -161,27 +161,27 @@
 [36mtest_file_1019.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 81":
 		<RBRACE> <TAB> <NEWLINE>
 test_file_1019.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: RETURN_PARENTHESIS   (line:   8, col:  12):	[0mReturn value must be in parenthesis[0m
-Error: FORBIDDEN_STRUCT     (line:  11, col:   1):	[0mStruct declaration are not allowed in .c files[0m
-Error: FORBIDDEN_CHAR_NAME  (line:  28, col:   9):	[0muser defined identifiers should contain only lowercase characters, digits or '_'[0m
-Error: COMMENT_ON_INSTR     (line:  35, col:   6):	[95mComment must be on its own line or at end of a line[0m
-Error: COMMENT_ON_INSTR     (line:  41, col:  10):	[95mComment must be on its own line or at end of a line[0m
-Error: WRONG_SCOPE_COMMENT  (line:  41, col:  10):	[95mComment is invalid in this scope[0m
-Error: COMMENT_ON_INSTR     (line:  42, col:  10):	[95mComment must be on its own line or at end of a line[0m
-Error: WRONG_SCOPE_COMMENT  (line:  42, col:  10):	[95mComment is invalid in this scope[0m
-Error: TOO_MANY_FUNCS       (line:  46, col:   1):	[92mToo many functions in file[0m
-Error: GOTO_FBIDDEN         (line:  50, col:   1):	[0mGoto statements are forbidden[0m
-Error: LABEL_FBIDDEN        (line:  52, col:   1):	[0mLabel statements are forbidden[0m
-Error: TOO_MANY_FUNCS       (line:  56, col:   1):	[92mToo many functions in file[0m
-Error: COMMENT_ON_INSTR     (line:  62, col:  27):	[95mComment must be on its own line or at end of a line[0m
-Error: WRONG_SCOPE_COMMENT  (line:  62, col:  27):	[95mComment is invalid in this scope[0m
-Error: TOO_MANY_FUNCS       (line:  66, col:   1):	[92mToo many functions in file[0m
-Error: COMMENT_ON_INSTR     (line:  70, col:  14):	[95mComment must be on its own line or at end of a line[0m
-Error: WRONG_SCOPE_COMMENT  (line:  70, col:  14):	[95mComment is invalid in this scope[0m
-Error: TOO_MANY_FUNCS       (line:  73, col:   1):	[92mToo many functions in file[0m
-Error: SPC_BEFORE_NL        (line:  73, col:  17):	[0mSpace before newline[0m
-Error: TOO_MANY_FUNCS       (line:  78, col:   1):	[92mToo many functions in file[0m
-Error: SPC_BEFORE_NL        (line:  78, col:  17):	[0mSpace before newline[0m
-Error: SPC_BEFORE_NL        (line:  79, col:   2):	[0mSpace before newline[0m
-Error: SPC_BEFORE_NL        (line:  81, col:   2):	[0mSpace before newline[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: RETURN_PARENTHESIS   (line:   8, col:  12):	Return value must be in parenthesis
+Error: FORBIDDEN_STRUCT     (line:  11, col:   1):	Struct declaration are not allowed in .c files
+Error: FORBIDDEN_CHAR_NAME  (line:  28, col:   9):	user defined identifiers should contain only lowercase characters, digits or '_'
+Error: COMMENT_ON_INSTR     (line:  35, col:   6):	Comment must be on its own line or at end of a line
+Error: COMMENT_ON_INSTR     (line:  41, col:  10):	Comment must be on its own line or at end of a line
+Error: WRONG_SCOPE_COMMENT  (line:  41, col:  10):	Comment is invalid in this scope
+Error: COMMENT_ON_INSTR     (line:  42, col:  10):	Comment must be on its own line or at end of a line
+Error: WRONG_SCOPE_COMMENT  (line:  42, col:  10):	Comment is invalid in this scope
+Error: TOO_MANY_FUNCS       (line:  46, col:   1):	Too many functions in file
+Error: GOTO_FBIDDEN         (line:  50, col:   1):	Goto statements are forbidden
+Error: LABEL_FBIDDEN        (line:  52, col:   1):	Label statements are forbidden
+Error: TOO_MANY_FUNCS       (line:  56, col:   1):	Too many functions in file
+Error: COMMENT_ON_INSTR     (line:  62, col:  27):	Comment must be on its own line or at end of a line
+Error: WRONG_SCOPE_COMMENT  (line:  62, col:  27):	Comment is invalid in this scope
+Error: TOO_MANY_FUNCS       (line:  66, col:   1):	Too many functions in file
+Error: COMMENT_ON_INSTR     (line:  70, col:  14):	Comment must be on its own line or at end of a line
+Error: WRONG_SCOPE_COMMENT  (line:  70, col:  14):	Comment is invalid in this scope
+Error: TOO_MANY_FUNCS       (line:  73, col:   1):	Too many functions in file
+Error: SPC_BEFORE_NL        (line:  73, col:  17):	Space before newline
+Error: TOO_MANY_FUNCS       (line:  78, col:   1):	Too many functions in file
+Error: SPC_BEFORE_NL        (line:  78, col:  17):	Space before newline
+Error: SPC_BEFORE_NL        (line:  79, col:   2):	Space before newline
+Error: SPC_BEFORE_NL        (line:  81, col:   2):	Space before newline

--- a/tests/rules/samples/test_file_1019_1.out
+++ b/tests/rules/samples/test_file_1019_1.out
@@ -29,7 +29,7 @@
 [36mtest_file_1019_1.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 15":
 		<RBRACE> <NEWLINE>
 test_file_1019_1.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: PREPROC_BAD_IFNDEF   (line:   1, col:   1):	[0mIfndef preprocessor statement without endif[0m
-Error: FORBIDDEN_TYPEDEF    (line:   4, col:   1):	[0mTypedef declaration are not allowed in .c files[0m
-Error: FORBIDDEN_STRUCT     (line:   5, col:   1):	[0mStruct declaration are not allowed in .c files[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: PREPROC_BAD_IFNDEF   (line:   1, col:   1):	Ifndef preprocessor statement without endif
+Error: FORBIDDEN_TYPEDEF    (line:   4, col:   1):	Typedef declaration are not allowed in .c files
+Error: FORBIDDEN_STRUCT     (line:   5, col:   1):	Struct declaration are not allowed in .c files

--- a/tests/rules/samples/test_file_1022.out
+++ b/tests/rules/samples/test_file_1022.out
@@ -27,7 +27,7 @@
 [36mtest_file_1022.c[0m - [32mIsBlockEnd[0m In "UserDefinedType" from "GlobalScope" line 14":
 		<RBRACE> <SEMI_COLON> 
 test_file_1022.c: Error!
-Error: FORBIDDEN_STRUCT     (line:   1, col:   1):	[0mStruct declaration are not allowed in .c files[0m
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: SPACE_REPLACE_TAB    (line:   9, col:   4):	[0mFound space when expecting tab[0m
-Error: FORBIDDEN_STRUCT     (line:  11, col:   1):	[0mStruct declaration are not allowed in .c files[0m
+Error: FORBIDDEN_STRUCT     (line:   1, col:   1):	Struct declaration are not allowed in .c files
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: SPACE_REPLACE_TAB    (line:   9, col:   4):	Found space when expecting tab
+Error: FORBIDDEN_STRUCT     (line:  11, col:   1):	Struct declaration are not allowed in .c files

--- a/tests/rules/samples/test_file_1116.out
+++ b/tests/rules/samples/test_file_1116.out
@@ -13,4 +13,4 @@
 [36mtest_file_1116.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 7":
 		<RBRACE> <NEWLINE>
 test_file_1116.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header

--- a/tests/rules/samples/test_file_1116_1.out
+++ b/tests/rules/samples/test_file_1116_1.out
@@ -13,5 +13,5 @@
 [36mtest_file_1116_1.c[0m - [32mIsBlockEnd[0m In "UserDefinedEnum" from "GlobalScope" line 7":
 		<RBRACE> <SEMI_COLON> 
 test_file_1116_1.c: Error!
-Error: FORBIDDEN_ENUM       (line:   1, col:   1):	[0mEnum declaration are not allowed in .c files[0m
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
+Error: FORBIDDEN_ENUM       (line:   1, col:   1):	Enum declaration are not allowed in .c files
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header

--- a/tests/rules/samples/test_file_1116_2.out
+++ b/tests/rules/samples/test_file_1116_2.out
@@ -19,5 +19,5 @@
 		<IDENTIFIER=fourth_enum_with_value_based_on_other_enums> <SPACE> <ASSIGN> <SPACE> <LPARENTHESIS> <IDENTIFIER=first_enum_with_value_zero> <NEWLINE>
 		<TAB> <TAB> <BWISE_OR> <SPACE> <IDENTIFIER=second_enum> <SPACE> <BWISE_OR> <SPACE> <IDENTIFIER=third_enum> <RPARENTHESIS> <SEMI_COLON> <NEWLINE>
 test_file_1116_2.c: Error!
-Error: FORBIDDEN_ENUM       (line:   1, col:   1):	[0mEnum declaration are not allowed in .c files[0m
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
+Error: FORBIDDEN_ENUM       (line:   1, col:   1):	Enum declaration are not allowed in .c files
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header

--- a/tests/rules/samples/test_file_1116_3.out
+++ b/tests/rules/samples/test_file_1116_3.out
@@ -9,4 +9,4 @@
 [36mtest_file_1116_3.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 5":
 		<RBRACE> <NEWLINE>
 test_file_1116_3.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header

--- a/tests/rules/samples/test_file_1807.out
+++ b/tests/rules/samples/test_file_1807.out
@@ -36,24 +36,24 @@
 [36mtest_file_1807.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 15":
 		<RBRACE> <NEWLINE>
 test_file_1807.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: TOO_FEW_TAB          (line:   3, col:  12):	[0mMissing tabs for indent level[0m
-Error: TOO_MANY_INSTR       (line:   3, col:  12):	[0mToo many instructions on a single line[0m
-Error: TOO_FEW_TAB          (line:   3, col:  19):	[0mMissing tabs for indent level[0m
-Error: TOO_MANY_INSTR       (line:   3, col:  19):	[0mToo many instructions on a single line[0m
-Error: TOO_FEW_TAB          (line:   4, col:  10):	[0mMissing tabs for indent level[0m
-Error: TOO_MANY_INSTR       (line:   4, col:  10):	[0mToo many instructions on a single line[0m
-Error: TOO_FEW_TAB          (line:   4, col:  15):	[0mMissing tabs for indent level[0m
-Error: TOO_MANY_INSTR       (line:   4, col:  15):	[0mToo many instructions on a single line[0m
-Error: NO_SPC_AFR_PAR       (line:   5, col:  16):	[94mExtra space after parenthesis (brace/bracket)[0m
-Error: TAB_INSTEAD_SPC      (line:   5, col:  17):	[94mFound tab when expecting space[0m
-Error: SPACE_AFTER_KW       (line:   6, col:   9):	[0mMissing space after keyword[0m
-Error: TAB_INSTEAD_SPC      (line:   8, col:  11):	[94mFound tab when expecting space[0m
-Error: TOO_FEW_TAB          (line:  10, col:  16):	[0mMissing tabs for indent level[0m
-Error: TOO_FEW_TAB          (line:  10, col:  16):	[0mMissing tabs for indent level[0m
-Error: TOO_MANY_INSTR       (line:  10, col:  16):	[0mToo many instructions on a single line[0m
-Error: MULT_ASSIGN_LINE     (line:  10, col:  25):	[0mMultiple assignations on a single line[0m
-Error: NO_SPC_AFR_PAR       (line:  13, col:   5):	[94mExtra space after parenthesis (brace/bracket)[0m
-Error: TAB_INSTEAD_SPC      (line:  13, col:   6):	[94mFound tab when expecting space[0m
-Error: SPC_BFR_OPERATOR     (line:  13, col:  61):	[94mmissing space before operator[0m
-Error: SPC_BFR_PAR          (line:  13, col:  62):	[94mMissing space before parenthesis (brace/bracket)[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: TOO_FEW_TAB          (line:   3, col:  12):	Missing tabs for indent level
+Error: TOO_MANY_INSTR       (line:   3, col:  12):	Too many instructions on a single line
+Error: TOO_FEW_TAB          (line:   3, col:  19):	Missing tabs for indent level
+Error: TOO_MANY_INSTR       (line:   3, col:  19):	Too many instructions on a single line
+Error: TOO_FEW_TAB          (line:   4, col:  10):	Missing tabs for indent level
+Error: TOO_MANY_INSTR       (line:   4, col:  10):	Too many instructions on a single line
+Error: TOO_FEW_TAB          (line:   4, col:  15):	Missing tabs for indent level
+Error: TOO_MANY_INSTR       (line:   4, col:  15):	Too many instructions on a single line
+Error: NO_SPC_AFR_PAR       (line:   5, col:  16):	Extra space after parenthesis (brace/bracket)
+Error: TAB_INSTEAD_SPC      (line:   5, col:  17):	Found tab when expecting space
+Error: SPACE_AFTER_KW       (line:   6, col:   9):	Missing space after keyword
+Error: TAB_INSTEAD_SPC      (line:   8, col:  11):	Found tab when expecting space
+Error: TOO_FEW_TAB          (line:  10, col:  16):	Missing tabs for indent level
+Error: TOO_FEW_TAB          (line:  10, col:  16):	Missing tabs for indent level
+Error: TOO_MANY_INSTR       (line:  10, col:  16):	Too many instructions on a single line
+Error: MULT_ASSIGN_LINE     (line:  10, col:  25):	Multiple assignations on a single line
+Error: NO_SPC_AFR_PAR       (line:  13, col:   5):	Extra space after parenthesis (brace/bracket)
+Error: TAB_INSTEAD_SPC      (line:  13, col:   6):	Found tab when expecting space
+Error: SPC_BFR_OPERATOR     (line:  13, col:  61):	missing space before operator
+Error: SPC_BFR_PAR          (line:  13, col:  62):	Missing space before parenthesis (brace/bracket)

--- a/tests/rules/samples/test_file_2007.out
+++ b/tests/rules/samples/test_file_2007.out
@@ -31,9 +31,9 @@
 [36mtest_file_2007.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 16":
 		<RBRACE> <NEWLINE>
 test_file_2007.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: SPACE_REPLACE_TAB    (line:   3, col:   9):	[0mFound space when expecting tab[0m
-Error: LINE_TOO_LONG        (line:   7, col:  82):	[94mline too long[0m
-Error: LINE_TOO_LONG        (line:   8, col:  82):	[94mline too long[0m
-Error: LINE_TOO_LONG        (line:  10, col: 117):	[94mline too long[0m
-Error: LINE_TOO_LONG        (line:  11, col:  82):	[94mline too long[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: SPACE_REPLACE_TAB    (line:   3, col:   9):	Found space when expecting tab
+Error: LINE_TOO_LONG        (line:   7, col:  82):	line too long
+Error: LINE_TOO_LONG        (line:   8, col:  82):	line too long
+Error: LINE_TOO_LONG        (line:  10, col: 117):	line too long
+Error: LINE_TOO_LONG        (line:  11, col:  82):	line too long

--- a/tests/rules/samples/test_file_210128.out
+++ b/tests/rules/samples/test_file_210128.out
@@ -38,13 +38,13 @@
 [36mtest_file_210128.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 19":
 		<RBRACE> <NEWLINE>
 test_file_210128.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: WRONG_SCOPE_COMMENT  (line:   5, col:  14):	[95mComment is invalid in this scope[0m
-Error: WRONG_SCOPE_COMMENT  (line:   5, col:  14):	[95mComment is invalid in this scope[0m
-Error: WRONG_SCOPE_COMMENT  (line:   5, col:  63):	[95mComment is invalid in this scope[0m
-Error: WRONG_SCOPE_COMMENT  (line:   5, col:  63):	[95mComment is invalid in this scope[0m
-Error: WRONG_SCOPE_COMMENT  (line:   5, col:  63):	[95mComment is invalid in this scope[0m
-Error: WRONG_SCOPE_COMMENT  (line:   6, col:   5):	[95mComment is invalid in this scope[0m
-Error: WRONG_SCOPE_COMMENT  (line:  12, col:  36):	[95mComment is invalid in this scope[0m
-Error: WRONG_SCOPE_COMMENT  (line:  18, col:  17):	[95mComment is invalid in this scope[0m
-Error: WRONG_SCOPE_COMMENT  (line:  18, col:  17):	[95mComment is invalid in this scope[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: WRONG_SCOPE_COMMENT  (line:   5, col:  14):	Comment is invalid in this scope
+Error: WRONG_SCOPE_COMMENT  (line:   5, col:  14):	Comment is invalid in this scope
+Error: WRONG_SCOPE_COMMENT  (line:   5, col:  63):	Comment is invalid in this scope
+Error: WRONG_SCOPE_COMMENT  (line:   5, col:  63):	Comment is invalid in this scope
+Error: WRONG_SCOPE_COMMENT  (line:   5, col:  63):	Comment is invalid in this scope
+Error: WRONG_SCOPE_COMMENT  (line:   6, col:   5):	Comment is invalid in this scope
+Error: WRONG_SCOPE_COMMENT  (line:  12, col:  36):	Comment is invalid in this scope
+Error: WRONG_SCOPE_COMMENT  (line:  18, col:  17):	Comment is invalid in this scope
+Error: WRONG_SCOPE_COMMENT  (line:  18, col:  17):	Comment is invalid in this scope

--- a/tests/rules/samples/test_file_210128_2.out
+++ b/tests/rules/samples/test_file_210128_2.out
@@ -5,7 +5,7 @@
 [36mtest_file_210128_2.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 1":
 		<RBRACE> <NEWLINE>
 test_file_210128_2.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: BRACE_NEWLINE        (line:   1, col:  48):	[93mExpected newline before brace[0m
-Error: BRACE_SHOULD_EOL     (line:   1, col:  48):	[0mExpected newline after brace[0m
-Error: TOO_MANY_INSTR       (line:   1, col:  49):	[0mToo many instructions on a single line[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: BRACE_NEWLINE        (line:   1, col:  48):	Expected newline before brace
+Error: BRACE_SHOULD_EOL     (line:   1, col:  48):	Expected newline after brace
+Error: TOO_MANY_INSTR       (line:   1, col:  49):	Too many instructions on a single line

--- a/tests/rules/samples/test_file_210131.out
+++ b/tests/rules/samples/test_file_210131.out
@@ -13,4 +13,4 @@
 [36mtest_file_210131.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 8":
 		<RBRACE> <NEWLINE>
 test_file_210131.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header

--- a/tests/rules/samples/test_file_210201.out
+++ b/tests/rules/samples/test_file_210201.out
@@ -25,9 +25,9 @@
 [36mtest_file_210201.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 13":
 		<RBRACE> <NEWLINE>
 test_file_210201.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: RETURN_PARENTHESIS   (line:   3, col:  20):	[0mReturn value must be in parenthesis[0m
-Error: RETURN_PARENTHESIS   (line:   4, col:  17):	[0mReturn value must be in parenthesis[0m
-Error: RETURN_PARENTHESIS   (line:   5, col:  18):	[0mReturn value must be in parenthesis[0m
-Error: RETURN_PARENTHESIS   (line:   6, col:  20):	[0mReturn value must be in parenthesis[0m
-Error: RETURN_PARENTHESIS   (line:   7, col:  17):	[0mReturn value must be in parenthesis[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: RETURN_PARENTHESIS   (line:   3, col:  20):	Return value must be in parenthesis
+Error: RETURN_PARENTHESIS   (line:   4, col:  17):	Return value must be in parenthesis
+Error: RETURN_PARENTHESIS   (line:   5, col:  18):	Return value must be in parenthesis
+Error: RETURN_PARENTHESIS   (line:   6, col:  20):	Return value must be in parenthesis
+Error: RETURN_PARENTHESIS   (line:   7, col:  17):	Return value must be in parenthesis

--- a/tests/rules/samples/test_file_210201_2.out
+++ b/tests/rules/samples/test_file_210201_2.out
@@ -56,9 +56,9 @@
 [36mtest_file_210201_2.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 29":
 		<RBRACE> <NEWLINE>
 test_file_210201_2.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: VAR_DECL_START_FUNC  (line:  15, col:   1):	[0mVariable declaration not at start of function[0m
-Error: SPC_AFTER_POINTER    (line:  15, col:  29):	[94mspace after pointer[0m
-Error: COMMA_START_LINE     (line:  15, col:  51):	[0mComma at line start[0m
-Error: VAR_DECL_START_FUNC  (line:  26, col:   1):	[0mVariable declaration not at start of function[0m
-Error: SPACE_REPLACE_TAB    (line:  26, col:   8):	[0mFound space when expecting tab[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: VAR_DECL_START_FUNC  (line:  15, col:   1):	Variable declaration not at start of function
+Error: SPC_AFTER_POINTER    (line:  15, col:  29):	space after pointer
+Error: COMMA_START_LINE     (line:  15, col:  51):	Comma at line start
+Error: VAR_DECL_START_FUNC  (line:  26, col:   1):	Variable declaration not at start of function
+Error: SPACE_REPLACE_TAB    (line:  26, col:   8):	Found space when expecting tab

--- a/tests/rules/samples/test_file_210205.out
+++ b/tests/rules/samples/test_file_210205.out
@@ -11,4 +11,4 @@
 [36mtest_file_210205.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 6":
 		<RBRACE> <NEWLINE>
 test_file_210205.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header

--- a/tests/rules/samples/test_file_210218.out
+++ b/tests/rules/samples/test_file_210218.out
@@ -7,4 +7,4 @@
 [36mtest_file_210218.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 4":
 		<RBRACE> <NEWLINE>
 test_file_210218.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header

--- a/tests/rules/samples/test_file_210218_2.out
+++ b/tests/rules/samples/test_file_210218_2.out
@@ -14,4 +14,4 @@
 [36mtest_file_210218_2.c[0m - [32mIsPreprocessorStatement[0m In "GlobalScope" from "None" line 9":
 		<HASH> <IDENTIFIER=endif> 
 test_file_210218_2.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header

--- a/tests/rules/samples/test_file_210218_3.out
+++ b/tests/rules/samples/test_file_210218_3.out
@@ -9,9 +9,9 @@
 [36mtest_file_210218_3.c[0m - [32mIsUserDefinedType[0m In "GlobalScope" from "None" line 5":
 		<TYPEDEF> <SPACE> <VOID> <TAB> <LPARENTHESIS> <MULT> <IDENTIFIER=t_func_definiton> <RPARENTHESIS> <LPARENTHESIS> <IDENTIFIER=toto> <SPACE> <IDENTIFIER=arg> <RPARENTHESIS> <SEMI_COLON> 
 test_file_210218_3.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: FORBIDDEN_TYPEDEF    (line:   2, col:   1):	[0mTypedef declaration are not allowed in .c files[0m
-Error: NL_AFTER_PREPROC     (line:   2, col:   1):	[0mPreprocessor statement must be followed by a newline[0m
-Error: FORBIDDEN_TYPEDEF    (line:   3, col:   1):	[0mTypedef declaration are not allowed in .c files[0m
-Error: FORBIDDEN_CHAR_NAME  (line:   3, col:  24):	[0muser defined identifiers should contain only lowercase characters, digits or '_'[0m
-Error: FORBIDDEN_TYPEDEF    (line:   5, col:   1):	[0mTypedef declaration are not allowed in .c files[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: FORBIDDEN_TYPEDEF    (line:   2, col:   1):	Typedef declaration are not allowed in .c files
+Error: NL_AFTER_PREPROC     (line:   2, col:   1):	Preprocessor statement must be followed by a newline
+Error: FORBIDDEN_TYPEDEF    (line:   3, col:   1):	Typedef declaration are not allowed in .c files
+Error: FORBIDDEN_CHAR_NAME  (line:   3, col:  24):	user defined identifiers should contain only lowercase characters, digits or '_'
+Error: FORBIDDEN_TYPEDEF    (line:   5, col:   1):	Typedef declaration are not allowed in .c files

--- a/tests/rules/samples/test_file_210223.out
+++ b/tests/rules/samples/test_file_210223.out
@@ -23,6 +23,6 @@
 [36mtest_file_210223.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 14":
 		<RBRACE> <NEWLINE>
 test_file_210223.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: MIXED_SPACE_TAB      (line:   3, col:  61):	[93mMixed spaces and tabs[0m
-Error: TAB_INSTEAD_SPC      (line:   4, col:   1):	[94mFound tab when expecting space[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: MIXED_SPACE_TAB      (line:   3, col:  61):	Mixed spaces and tabs
+Error: TAB_INSTEAD_SPC      (line:   4, col:   1):	Found tab when expecting space

--- a/tests/rules/samples/test_file_210304.out
+++ b/tests/rules/samples/test_file_210304.out
@@ -56,7 +56,7 @@
 [36mtest_file_210304.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 31":
 		<RBRACE> <NEWLINE>
 test_file_210304.c: Error!
-Error: FORBIDDEN_TYPEDEF    (line:   1, col:   1):	[0mTypedef declaration are not allowed in .c files[0m
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: FORBIDDEN_TYPEDEF    (line:   6, col:   1):	[0mTypedef declaration are not allowed in .c files[0m
-Error: FORBIDDEN_TYPEDEF    (line:  14, col:   1):	[0mTypedef declaration are not allowed in .c files[0m
+Error: FORBIDDEN_TYPEDEF    (line:   1, col:   1):	Typedef declaration are not allowed in .c files
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: FORBIDDEN_TYPEDEF    (line:   6, col:   1):	Typedef declaration are not allowed in .c files
+Error: FORBIDDEN_TYPEDEF    (line:  14, col:   1):	Typedef declaration are not allowed in .c files

--- a/tests/rules/samples/test_file_210308.out
+++ b/tests/rules/samples/test_file_210308.out
@@ -61,8 +61,8 @@
 [36mtest_file_210308.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 35":
 		<RBRACE> <NEWLINE>
 test_file_210308.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: NEWLINE_PRECEDES_FUNC (line:  29, col:   1):	[0mFunctions must be separated by a newline[0m
-Error: NEWLINE_PRECEDES_FUNC (line:  33, col:   1):	[0mFunctions must be separated by a newline[0m
-Error: NL_AFTER_PREPROC     (line:  33, col:   1):	[0mPreprocessor statement must be followed by a newline[0m
-Error: TOO_MANY_FUNCS       (line:  33, col:   1):	[92mToo many functions in file[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: NEWLINE_PRECEDES_FUNC (line:  29, col:   1):	Functions must be separated by a newline
+Error: NEWLINE_PRECEDES_FUNC (line:  33, col:   1):	Functions must be separated by a newline
+Error: NL_AFTER_PREPROC     (line:  33, col:   1):	Preprocessor statement must be followed by a newline
+Error: TOO_MANY_FUNCS       (line:  33, col:   1):	Too many functions in file

--- a/tests/rules/samples/test_file_210308_2.out
+++ b/tests/rules/samples/test_file_210308_2.out
@@ -9,5 +9,5 @@
 [36mtest_file_210308_2.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 5":
 		<RBRACE> <NEWLINE>
 test_file_210308_2.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: ASSIGN_IN_CONTROL    (line:   3, col:  23):	[0mAssignment in control structure[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: ASSIGN_IN_CONTROL    (line:   3, col:  23):	Assignment in control structure

--- a/tests/rules/samples/test_file_210308_3.out
+++ b/tests/rules/samples/test_file_210308_3.out
@@ -15,4 +15,4 @@
 [36mtest_file_210308_3.c[0m - [32mIsPreprocessorStatement[0m In "GlobalScope" from "None" line 8":
 		<HASH> <IDENTIFIER=endif> 
 test_file_210308_3.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header

--- a/tests/rules/samples/test_file_210316.out
+++ b/tests/rules/samples/test_file_210316.out
@@ -57,21 +57,21 @@
 [36mtest_file_210316.c[0m - [32mIsAssignation[0m In "GlobalScope" from "None" line 38":
 		<MULT> <IDENTIFIER=result> <SPACE> <ASSIGN> <SPACE> <LPARENTHESIS> <IDENTIFIER=t_quaternion> <RPARENTHESIS> <LBRACE> <IDENTIFIER=r> <SPACE> <COLON> <SPACE> <CONSTANT=1> <COMMA> <SPACE> <IDENTIFIER=i> <SPACE> <COLON> <SPACE> <CONSTANT=0> <COMMA> <SPACE> <IDENTIFIER=j> <SPACE> <COLON> <SPACE> <CONSTANT=0> <COMMA> <SPACE> <IDENTIFIER=k> <SPACE> <COLON> <SPACE> <CONSTANT=0> <SPACE> <RBRACE> <SEMI_COLON> 
 test_file_210316.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: SPACE_AFTER_KW       (line:   3, col:  20):	[0mMissing space after keyword[0m
-Error: SPACE_AFTER_KW       (line:   3, col:  50):	[0mMissing space after keyword[0m
-Error: SPACE_AFTER_KW       (line:   4, col:  28):	[0mMissing space after keyword[0m
-Error: SPACE_AFTER_KW       (line:   4, col:  57):	[0mMissing space after keyword[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: SPACE_AFTER_KW       (line:   3, col:  20):	Missing space after keyword
+Error: SPACE_AFTER_KW       (line:   3, col:  50):	Missing space after keyword
+Error: SPACE_AFTER_KW       (line:   4, col:  28):	Missing space after keyword
+Error: SPACE_AFTER_KW       (line:   4, col:  57):	Missing space after keyword
 Notice: GLOBAL_VAR_DETECTED  (line:   7, col:   1):	Global variable present in file. Make sure it is a reasonable choice.
-Error: DECL_ASSIGN_LINE     (line:  13, col:  28):	[0mDeclaration and assignation on a single line[0m
-Error: DECL_ASSIGN_LINE     (line:  14, col:  12):	[0mDeclaration and assignation on a single line[0m
-Error: DECL_ASSIGN_LINE     (line:  15, col:  12):	[0mDeclaration and assignation on a single line[0m
-Error: DECL_ASSIGN_LINE     (line:  16, col:  12):	[0mDeclaration and assignation on a single line[0m
-Error: DECL_ASSIGN_LINE     (line:  17, col:  12):	[0mDeclaration and assignation on a single line[0m
+Error: DECL_ASSIGN_LINE     (line:  13, col:  28):	Declaration and assignation on a single line
+Error: DECL_ASSIGN_LINE     (line:  14, col:  12):	Declaration and assignation on a single line
+Error: DECL_ASSIGN_LINE     (line:  15, col:  12):	Declaration and assignation on a single line
+Error: DECL_ASSIGN_LINE     (line:  16, col:  12):	Declaration and assignation on a single line
+Error: DECL_ASSIGN_LINE     (line:  17, col:  12):	Declaration and assignation on a single line
 Notice: GLOBAL_VAR_DETECTED  (line:  20, col:   1):	Global variable present in file. Make sure it is a reasonable choice.
 Notice: GLOBAL_VAR_DETECTED  (line:  34, col:   1):	Global variable present in file. Make sure it is a reasonable choice.
 Notice: GLOBAL_VAR_DETECTED  (line:  35, col:   1):	Global variable present in file. Make sure it is a reasonable choice.
-Error: NO_SPC_BFR_PAR       (line:  35, col:  65):	[94mExtra space before parenthesis (brace/bracket)[0m
+Error: NO_SPC_BFR_PAR       (line:  35, col:  65):	Extra space before parenthesis (brace/bracket)
 Notice: GLOBAL_VAR_DETECTED  (line:  36, col:   1):	Global variable present in file. Make sure it is a reasonable choice.
-Error: NO_SPC_BFR_PAR       (line:  36, col:  64):	[94mExtra space before parenthesis (brace/bracket)[0m
-Error: NO_SPC_BFR_PAR       (line:  38, col:  53):	[94mExtra space before parenthesis (brace/bracket)[0m
+Error: NO_SPC_BFR_PAR       (line:  36, col:  64):	Extra space before parenthesis (brace/bracket)
+Error: NO_SPC_BFR_PAR       (line:  38, col:  53):	Extra space before parenthesis (brace/bracket)

--- a/tests/rules/samples/test_file_210322.out
+++ b/tests/rules/samples/test_file_210322.out
@@ -17,4 +17,4 @@
 [36mtest_file_210322.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 12":
 		<RBRACE> <NEWLINE>
 test_file_210322.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header

--- a/tests/rules/samples/test_file_210412.out
+++ b/tests/rules/samples/test_file_210412.out
@@ -37,6 +37,6 @@
 [36mtest_file_210412.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 21":
 		<RBRACE> 
 test_file_210412.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: SPACE_BEFORE_FUNC    (line:  14, col:   4):	[94mspace before function name[0m
-Error: BRACE_SHOULD_EOL     (line:  21, col:   1):	[0mExpected newline after brace[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: SPACE_BEFORE_FUNC    (line:  14, col:   4):	space before function name
+Error: BRACE_SHOULD_EOL     (line:  21, col:   1):	Expected newline after brace

--- a/tests/rules/samples/test_file_210923.out
+++ b/tests/rules/samples/test_file_210923.out
@@ -218,40 +218,40 @@
 [36mtest_file_210923.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 107":
 		<RBRACE> <NEWLINE>
 test_file_210923.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: MULT_ASSIGN_LINE     (line:   6, col:  16):	[0mMultiple assignations on a single line[0m
-Error: INCLUDE_START_FILE   (line:   9, col:   1):	[0mInclude must be at the start of file[0m
-Error: TOO_FEW_TAB          (line:  15, col:  13):	[0mMissing tabs for indent level[0m
-Error: TOO_MANY_INSTR       (line:  15, col:  13):	[0mToo many instructions on a single line[0m
-Error: TOO_FEW_TAB          (line:  23, col:  24):	[0mMissing tabs for indent level[0m
-Error: TOO_MANY_INSTR       (line:  23, col:  24):	[0mToo many instructions on a single line[0m
-Error: TOO_FEW_TAB          (line:  31, col:  12):	[0mMissing tabs for indent level[0m
-Error: TOO_MANY_INSTR       (line:  31, col:  12):	[0mToo many instructions on a single line[0m
-Error: TOO_MANY_FUNCS       (line:  47, col:   1):	[92mToo many functions in file[0m
-Error: LINE_TOO_LONG        (line:  52, col:  88):	[94mline too long[0m
-Error: TOO_MANY_FUNCS       (line:  54, col:   1):	[92mToo many functions in file[0m
-Error: TOO_MANY_FUNCS       (line:  59, col:   1):	[92mToo many functions in file[0m
-Error: LINE_TOO_LONG        (line:  63, col:  84):	[94mline too long[0m
-Error: TOO_MANY_FUNCS       (line:  66, col:   1):	[92mToo many functions in file[0m
-Error: LINE_TOO_LONG        (line:  70, col:  84):	[94mline too long[0m
-Error: TOO_MANY_FUNCS       (line:  73, col:   1):	[92mToo many functions in file[0m
-Error: SPACE_REPLACE_TAB    (line:  75, col:  10):	[0mFound space when expecting tab[0m
-Error: SPC_AFTER_POINTER    (line:  75, col:  11):	[94mspace after pointer[0m
-Error: DECL_ASSIGN_LINE     (line:  75, col:  24):	[0mDeclaration and assignation on a single line[0m
-Error: SPACE_REPLACE_TAB    (line:  76, col:  10):	[0mFound space when expecting tab[0m
-Error: SPC_AFTER_POINTER    (line:  76, col:  11):	[94mspace after pointer[0m
-Error: DECL_ASSIGN_LINE     (line:  76, col:  24):	[0mDeclaration and assignation on a single line[0m
-Error: SPACE_REPLACE_TAB    (line:  77, col:  10):	[0mFound space when expecting tab[0m
-Error: SPC_AFTER_POINTER    (line:  77, col:  11):	[94mspace after pointer[0m
-Error: DECL_ASSIGN_LINE     (line:  77, col:  24):	[0mDeclaration and assignation on a single line[0m
-Error: SPACE_REPLACE_TAB    (line:  78, col:  10):	[0mFound space when expecting tab[0m
-Error: SPC_AFTER_POINTER    (line:  78, col:  11):	[94mspace after pointer[0m
-Error: DECL_ASSIGN_LINE     (line:  78, col:  24):	[0mDeclaration and assignation on a single line[0m
-Error: SPACE_REPLACE_TAB    (line:  79, col:  10):	[0mFound space when expecting tab[0m
-Error: SPC_AFTER_POINTER    (line:  79, col:  11):	[94mspace after pointer[0m
-Error: DECL_ASSIGN_LINE     (line:  79, col:  24):	[0mDeclaration and assignation on a single line[0m
-Error: TOO_MANY_VARS_FUNC   (line:  80, col:   1):	[91mToo many variables declarations in a function[0m
-Error: SPACE_REPLACE_TAB    (line:  80, col:  10):	[0mFound space when expecting tab[0m
-Error: SPC_AFTER_POINTER    (line:  80, col:  11):	[94mspace after pointer[0m
-Error: DECL_ASSIGN_LINE     (line:  80, col:  24):	[0mDeclaration and assignation on a single line[0m
-Error: TOO_MANY_FUNCS       (line:  83, col:   1):	[92mToo many functions in file[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: MULT_ASSIGN_LINE     (line:   6, col:  16):	Multiple assignations on a single line
+Error: INCLUDE_START_FILE   (line:   9, col:   1):	Include must be at the start of file
+Error: TOO_FEW_TAB          (line:  15, col:  13):	Missing tabs for indent level
+Error: TOO_MANY_INSTR       (line:  15, col:  13):	Too many instructions on a single line
+Error: TOO_FEW_TAB          (line:  23, col:  24):	Missing tabs for indent level
+Error: TOO_MANY_INSTR       (line:  23, col:  24):	Too many instructions on a single line
+Error: TOO_FEW_TAB          (line:  31, col:  12):	Missing tabs for indent level
+Error: TOO_MANY_INSTR       (line:  31, col:  12):	Too many instructions on a single line
+Error: TOO_MANY_FUNCS       (line:  47, col:   1):	Too many functions in file
+Error: LINE_TOO_LONG        (line:  52, col:  88):	line too long
+Error: TOO_MANY_FUNCS       (line:  54, col:   1):	Too many functions in file
+Error: TOO_MANY_FUNCS       (line:  59, col:   1):	Too many functions in file
+Error: LINE_TOO_LONG        (line:  63, col:  84):	line too long
+Error: TOO_MANY_FUNCS       (line:  66, col:   1):	Too many functions in file
+Error: LINE_TOO_LONG        (line:  70, col:  84):	line too long
+Error: TOO_MANY_FUNCS       (line:  73, col:   1):	Too many functions in file
+Error: SPACE_REPLACE_TAB    (line:  75, col:  10):	Found space when expecting tab
+Error: SPC_AFTER_POINTER    (line:  75, col:  11):	space after pointer
+Error: DECL_ASSIGN_LINE     (line:  75, col:  24):	Declaration and assignation on a single line
+Error: SPACE_REPLACE_TAB    (line:  76, col:  10):	Found space when expecting tab
+Error: SPC_AFTER_POINTER    (line:  76, col:  11):	space after pointer
+Error: DECL_ASSIGN_LINE     (line:  76, col:  24):	Declaration and assignation on a single line
+Error: SPACE_REPLACE_TAB    (line:  77, col:  10):	Found space when expecting tab
+Error: SPC_AFTER_POINTER    (line:  77, col:  11):	space after pointer
+Error: DECL_ASSIGN_LINE     (line:  77, col:  24):	Declaration and assignation on a single line
+Error: SPACE_REPLACE_TAB    (line:  78, col:  10):	Found space when expecting tab
+Error: SPC_AFTER_POINTER    (line:  78, col:  11):	space after pointer
+Error: DECL_ASSIGN_LINE     (line:  78, col:  24):	Declaration and assignation on a single line
+Error: SPACE_REPLACE_TAB    (line:  79, col:  10):	Found space when expecting tab
+Error: SPC_AFTER_POINTER    (line:  79, col:  11):	space after pointer
+Error: DECL_ASSIGN_LINE     (line:  79, col:  24):	Declaration and assignation on a single line
+Error: TOO_MANY_VARS_FUNC   (line:  80, col:   1):	Too many variables declarations in a function
+Error: SPACE_REPLACE_TAB    (line:  80, col:  10):	Found space when expecting tab
+Error: SPC_AFTER_POINTER    (line:  80, col:  11):	space after pointer
+Error: DECL_ASSIGN_LINE     (line:  80, col:  24):	Declaration and assignation on a single line
+Error: TOO_MANY_FUNCS       (line:  83, col:   1):	Too many functions in file

--- a/tests/rules/samples/test_file_operators.out
+++ b/tests/rules/samples/test_file_operators.out
@@ -17,4 +17,4 @@
 [36mtest_file_operators.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 9":
 		<RBRACE> <NEWLINE>
 test_file_operators.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header

--- a/tests/rules/samples/test_islabel.out
+++ b/tests/rules/samples/test_islabel.out
@@ -106,46 +106,46 @@
 [36mtest_islabel.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 55":
 		<RBRACE> <NEWLINE>
 test_islabel.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: GOTO_FBIDDEN         (line:  11, col:   1):	[0mGoto statements are forbidden[0m
-Error: NO_SPC_AFR_PAR       (line:  12, col:  15):	[94mExtra space after parenthesis (brace/bracket)[0m
-Error: TOO_FEW_TAB          (line:  12, col:  17):	[0mMissing tabs for indent level[0m
-Error: GOTO_FBIDDEN         (line:  13, col:   1):	[0mGoto statements are forbidden[0m
-Error: GOTO_FBIDDEN         (line:  15, col:   1):	[0mGoto statements are forbidden[0m
-Error: LABEL_FBIDDEN        (line:  16, col:   1):	[0mLabel statements are forbidden[0m
-Error: LABEL_FBIDDEN        (line:  20, col:   1):	[0mLabel statements are forbidden[0m
-Error: TOO_MANY_TAB         (line:  21, col:   1):	[0mExtra tabs for indent level[0m
-Error: LABEL_FBIDDEN        (line:  22, col:   1):	[0mLabel statements are forbidden[0m
-Error: TOO_FEW_TAB          (line:  22, col:   1):	[0mMissing tabs for indent level[0m
-Error: LABEL_FBIDDEN        (line:  24, col:   1):	[0mLabel statements are forbidden[0m
-Error: TOO_FEW_TAB          (line:  24, col:   1):	[0mMissing tabs for indent level[0m
-Error: LABEL_FBIDDEN        (line:  25, col:   1):	[0mLabel statements are forbidden[0m
-Error: TOO_FEW_TAB          (line:  25, col:   1):	[0mMissing tabs for indent level[0m
-Error: VAR_DECL_START_FUNC  (line:  25, col:   1):	[0mVariable declaration not at start of function[0m
-Error: SPACE_REPLACE_TAB    (line:  25, col:   4):	[0mFound space when expecting tab[0m
-Error: TOO_FEW_TAB          (line:  26, col:   1):	[0mMissing tabs for indent level[0m
-Error: MIXED_SPACE_TAB      (line:  27, col:   1):	[93mMixed spaces and tabs[0m
-Error: TOO_FEW_TAB          (line:  27, col:   1):	[0mMissing tabs for indent level[0m
-Error: NO_SPC_BFR_OPR       (line:  27, col:   6):	[94mextra space before operator[0m
-Error: SPC_BEFORE_NL        (line:  27, col:   7):	[0mSpace before newline[0m
-Error: LABEL_FBIDDEN        (line:  28, col:   1):	[0mLabel statements are forbidden[0m
-Error: TOO_FEW_TAB          (line:  28, col:   1):	[0mMissing tabs for indent level[0m
-Error: TOO_MANY_INSTR       (line:  33, col:   2):	[0mToo many instructions on a single line[0m
-Error: LABEL_FBIDDEN        (line:  40, col:   1):	[0mLabel statements are forbidden[0m
-Error: TOO_FEW_TAB          (line:  40, col:   1):	[0mMissing tabs for indent level[0m
-Error: GOTO_FBIDDEN         (line:  42, col:   1):	[0mGoto statements are forbidden[0m
-Error: GOTO_FBIDDEN         (line:  45, col:   1):	[0mGoto statements are forbidden[0m
-Error: TOO_FEW_TAB          (line:  45, col:   1):	[0mMissing tabs for indent level[0m
-Error: LABEL_FBIDDEN        (line:  46, col:   1):	[0mLabel statements are forbidden[0m
-Error: TOO_FEW_TAB          (line:  46, col:   1):	[0mMissing tabs for indent level[0m
-Error: TOO_FEW_TAB          (line:  47, col:   1):	[0mMissing tabs for indent level[0m
-Error: TOO_FEW_TAB          (line:  48, col:   1):	[0mMissing tabs for indent level[0m
-Error: TOO_FEW_TAB          (line:  49, col:   1):	[0mMissing tabs for indent level[0m
-Error: GOTO_FBIDDEN         (line:  50, col:   1):	[0mGoto statements are forbidden[0m
-Error: TOO_FEW_TAB          (line:  50, col:   1):	[0mMissing tabs for indent level[0m
-Error: TOO_FEW_TAB          (line:  51, col:   1):	[0mMissing tabs for indent level[0m
-Error: TOO_FEW_TAB          (line:  52, col:   1):	[0mMissing tabs for indent level[0m
-Error: SPACE_REPLACE_TAB    (line:  52, col:   9):	[0mFound space when expecting tab[0m
-Error: GOTO_FBIDDEN         (line:  53, col:   1):	[0mGoto statements are forbidden[0m
-Error: TOO_FEW_TAB          (line:  53, col:   1):	[0mMissing tabs for indent level[0m
-Error: SPACE_REPLACE_TAB    (line:  53, col:  17):	[0mFound space when expecting tab[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: GOTO_FBIDDEN         (line:  11, col:   1):	Goto statements are forbidden
+Error: NO_SPC_AFR_PAR       (line:  12, col:  15):	Extra space after parenthesis (brace/bracket)
+Error: TOO_FEW_TAB          (line:  12, col:  17):	Missing tabs for indent level
+Error: GOTO_FBIDDEN         (line:  13, col:   1):	Goto statements are forbidden
+Error: GOTO_FBIDDEN         (line:  15, col:   1):	Goto statements are forbidden
+Error: LABEL_FBIDDEN        (line:  16, col:   1):	Label statements are forbidden
+Error: LABEL_FBIDDEN        (line:  20, col:   1):	Label statements are forbidden
+Error: TOO_MANY_TAB         (line:  21, col:   1):	Extra tabs for indent level
+Error: LABEL_FBIDDEN        (line:  22, col:   1):	Label statements are forbidden
+Error: TOO_FEW_TAB          (line:  22, col:   1):	Missing tabs for indent level
+Error: LABEL_FBIDDEN        (line:  24, col:   1):	Label statements are forbidden
+Error: TOO_FEW_TAB          (line:  24, col:   1):	Missing tabs for indent level
+Error: LABEL_FBIDDEN        (line:  25, col:   1):	Label statements are forbidden
+Error: TOO_FEW_TAB          (line:  25, col:   1):	Missing tabs for indent level
+Error: VAR_DECL_START_FUNC  (line:  25, col:   1):	Variable declaration not at start of function
+Error: SPACE_REPLACE_TAB    (line:  25, col:   4):	Found space when expecting tab
+Error: TOO_FEW_TAB          (line:  26, col:   1):	Missing tabs for indent level
+Error: MIXED_SPACE_TAB      (line:  27, col:   1):	Mixed spaces and tabs
+Error: TOO_FEW_TAB          (line:  27, col:   1):	Missing tabs for indent level
+Error: NO_SPC_BFR_OPR       (line:  27, col:   6):	extra space before operator
+Error: SPC_BEFORE_NL        (line:  27, col:   7):	Space before newline
+Error: LABEL_FBIDDEN        (line:  28, col:   1):	Label statements are forbidden
+Error: TOO_FEW_TAB          (line:  28, col:   1):	Missing tabs for indent level
+Error: TOO_MANY_INSTR       (line:  33, col:   2):	Too many instructions on a single line
+Error: LABEL_FBIDDEN        (line:  40, col:   1):	Label statements are forbidden
+Error: TOO_FEW_TAB          (line:  40, col:   1):	Missing tabs for indent level
+Error: GOTO_FBIDDEN         (line:  42, col:   1):	Goto statements are forbidden
+Error: GOTO_FBIDDEN         (line:  45, col:   1):	Goto statements are forbidden
+Error: TOO_FEW_TAB          (line:  45, col:   1):	Missing tabs for indent level
+Error: LABEL_FBIDDEN        (line:  46, col:   1):	Label statements are forbidden
+Error: TOO_FEW_TAB          (line:  46, col:   1):	Missing tabs for indent level
+Error: TOO_FEW_TAB          (line:  47, col:   1):	Missing tabs for indent level
+Error: TOO_FEW_TAB          (line:  48, col:   1):	Missing tabs for indent level
+Error: TOO_FEW_TAB          (line:  49, col:   1):	Missing tabs for indent level
+Error: GOTO_FBIDDEN         (line:  50, col:   1):	Goto statements are forbidden
+Error: TOO_FEW_TAB          (line:  50, col:   1):	Missing tabs for indent level
+Error: TOO_FEW_TAB          (line:  51, col:   1):	Missing tabs for indent level
+Error: TOO_FEW_TAB          (line:  52, col:   1):	Missing tabs for indent level
+Error: SPACE_REPLACE_TAB    (line:  52, col:   9):	Found space when expecting tab
+Error: GOTO_FBIDDEN         (line:  53, col:   1):	Goto statements are forbidden
+Error: TOO_FEW_TAB          (line:  53, col:   1):	Missing tabs for indent level
+Error: SPACE_REPLACE_TAB    (line:  53, col:  17):	Found space when expecting tab

--- a/tests/rules/samples/test_loop_inf.out
+++ b/tests/rules/samples/test_loop_inf.out
@@ -9,4 +9,4 @@
 [36mtest_loop_inf.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 5":
 		<RBRACE> <NEWLINE>
 test_loop_inf.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header

--- a/tests/rules/samples/test_multiple_lines_escaping.out
+++ b/tests/rules/samples/test_multiple_lines_escaping.out
@@ -1,4 +1,4 @@
 [36mtest_multiple_lines_escaping.c[0m - [32mIsComment[0m In "GlobalScope" from "None" line 1":
 		<COMMENT=//\ ola \ ola \ ola          oxi eita> <NEWLINE>
 test_multiple_lines_escaping.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header

--- a/tests/rules/samples/test_nl_after_var_decl.out
+++ b/tests/rules/samples/test_nl_after_var_decl.out
@@ -135,47 +135,47 @@
 [36mtest_nl_after_var_decl.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 58":
 		<RBRACE> <NEWLINE>
 test_nl_after_var_decl.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: NL_AFTER_VAR_DECL    (line:   4, col:   1):	[0mVariable declarations must be followed by a newline[0m
-Error: NL_AFTER_VAR_DECL    (line:  12, col:   1):	[0mVariable declarations must be followed by a newline[0m
-Error: BRACE_SHOULD_EOL     (line:  12, col:   5):	[0mExpected newline after brace[0m
-Error: TOO_FEW_TAB          (line:  12, col:   6):	[0mMissing tabs for indent level[0m
-Error: BRACE_SHOULD_EOL     (line:  12, col:   7):	[0mExpected newline after brace[0m
-Error: TOO_FEW_TAB          (line:  12, col:   8):	[0mMissing tabs for indent level[0m
-Error: TOO_MANY_INSTR       (line:  12, col:   8):	[0mToo many instructions on a single line[0m
-Error: BRACE_SHOULD_EOL     (line:  12, col:  19):	[0mExpected newline after brace[0m
-Error: TOO_FEW_TAB          (line:  12, col:  19):	[0mMissing tabs for indent level[0m
-Error: TOO_MANY_INSTR       (line:  12, col:  19):	[0mToo many instructions on a single line[0m
-Error: TOO_FEW_TAB          (line:  12, col:  20):	[0mMissing tabs for indent level[0m
-Error: TOO_MANY_INSTR       (line:  12, col:  20):	[0mToo many instructions on a single line[0m
-Error: NL_AFTER_VAR_DECL    (line:  18, col:   1):	[0mVariable declarations must be followed by a newline[0m
-Error: NL_AFTER_VAR_DECL    (line:  24, col:   1):	[0mVariable declarations must be followed by a newline[0m
-Error: MULT_DECL_LINE       (line:  32, col:  10):	[0mMultiple declarations on a single line[0m
-Error: MULT_DECL_LINE       (line:  32, col:  13):	[0mMultiple declarations on a single line[0m
-Error: NL_AFTER_VAR_DECL    (line:  33, col:   1):	[0mVariable declarations must be followed by a newline[0m
-Error: TOO_MANY_FUNCS       (line:  38, col:   1):	[92mToo many functions in file[0m
-Error: NL_AFTER_VAR_DECL    (line:  41, col:   1):	[0mVariable declarations must be followed by a newline[0m
-Error: TOO_FEW_TAB          (line:  43, col:   1):	[0mMissing tabs for indent level[0m
-Error: TOO_MANY_FUNCS       (line:  47, col:   1):	[92mToo many functions in file[0m
-Error: NL_AFTER_VAR_DECL    (line:  50, col:   1):	[0mVariable declarations must be followed by a newline[0m
-Error: BRACE_SHOULD_EOL     (line:  50, col:   5):	[0mExpected newline after brace[0m
-Error: BRACE_SHOULD_EOL     (line:  50, col:   6):	[0mExpected newline after brace[0m
-Error: TOO_FEW_TAB          (line:  50, col:   6):	[0mMissing tabs for indent level[0m
-Error: TOO_FEW_TAB          (line:  50, col:   7):	[0mMissing tabs for indent level[0m
-Error: TOO_MANY_INSTR       (line:  50, col:   7):	[0mToo many instructions on a single line[0m
-Error: NO_SPC_BFR_OPR       (line:  50, col:  14):	[94mextra space before operator[0m
-Error: BRACE_SHOULD_EOL     (line:  50, col:  15):	[0mExpected newline after brace[0m
-Error: TOO_FEW_TAB          (line:  50, col:  15):	[0mMissing tabs for indent level[0m
-Error: TOO_MANY_INSTR       (line:  50, col:  15):	[0mToo many instructions on a single line[0m
-Error: TOO_FEW_TAB          (line:  50, col:  16):	[0mMissing tabs for indent level[0m
-Error: TOO_MANY_INSTR       (line:  50, col:  16):	[0mToo many instructions on a single line[0m
-Error: TOO_MANY_FUNCS       (line:  53, col:   1):	[92mToo many functions in file[0m
-Error: NL_AFTER_VAR_DECL    (line:  56, col:   1):	[0mVariable declarations must be followed by a newline[0m
-Error: BRACE_SHOULD_EOL     (line:  56, col:   5):	[0mExpected newline after brace[0m
-Error: TOO_FEW_TAB          (line:  56, col:   6):	[0mMissing tabs for indent level[0m
-Error: TOO_MANY_INSTR       (line:  56, col:   6):	[0mToo many instructions on a single line[0m
-Error: MIXED_SPACE_TAB      (line:  57, col:   1):	[93mMixed spaces and tabs[0m
-Error: TOO_FEW_TAB          (line:  57, col:   1):	[0mMissing tabs for indent level[0m
-Error: NO_SPC_BFR_OPR       (line:  57, col:  16):	[94mextra space before operator[0m
-Error: TOO_FEW_TAB          (line:  57, col:  17):	[0mMissing tabs for indent level[0m
-Error: TOO_MANY_INSTR       (line:  57, col:  17):	[0mToo many instructions on a single line[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: NL_AFTER_VAR_DECL    (line:   4, col:   1):	Variable declarations must be followed by a newline
+Error: NL_AFTER_VAR_DECL    (line:  12, col:   1):	Variable declarations must be followed by a newline
+Error: BRACE_SHOULD_EOL     (line:  12, col:   5):	Expected newline after brace
+Error: TOO_FEW_TAB          (line:  12, col:   6):	Missing tabs for indent level
+Error: BRACE_SHOULD_EOL     (line:  12, col:   7):	Expected newline after brace
+Error: TOO_FEW_TAB          (line:  12, col:   8):	Missing tabs for indent level
+Error: TOO_MANY_INSTR       (line:  12, col:   8):	Too many instructions on a single line
+Error: BRACE_SHOULD_EOL     (line:  12, col:  19):	Expected newline after brace
+Error: TOO_FEW_TAB          (line:  12, col:  19):	Missing tabs for indent level
+Error: TOO_MANY_INSTR       (line:  12, col:  19):	Too many instructions on a single line
+Error: TOO_FEW_TAB          (line:  12, col:  20):	Missing tabs for indent level
+Error: TOO_MANY_INSTR       (line:  12, col:  20):	Too many instructions on a single line
+Error: NL_AFTER_VAR_DECL    (line:  18, col:   1):	Variable declarations must be followed by a newline
+Error: NL_AFTER_VAR_DECL    (line:  24, col:   1):	Variable declarations must be followed by a newline
+Error: MULT_DECL_LINE       (line:  32, col:  10):	Multiple declarations on a single line
+Error: MULT_DECL_LINE       (line:  32, col:  13):	Multiple declarations on a single line
+Error: NL_AFTER_VAR_DECL    (line:  33, col:   1):	Variable declarations must be followed by a newline
+Error: TOO_MANY_FUNCS       (line:  38, col:   1):	Too many functions in file
+Error: NL_AFTER_VAR_DECL    (line:  41, col:   1):	Variable declarations must be followed by a newline
+Error: TOO_FEW_TAB          (line:  43, col:   1):	Missing tabs for indent level
+Error: TOO_MANY_FUNCS       (line:  47, col:   1):	Too many functions in file
+Error: NL_AFTER_VAR_DECL    (line:  50, col:   1):	Variable declarations must be followed by a newline
+Error: BRACE_SHOULD_EOL     (line:  50, col:   5):	Expected newline after brace
+Error: BRACE_SHOULD_EOL     (line:  50, col:   6):	Expected newline after brace
+Error: TOO_FEW_TAB          (line:  50, col:   6):	Missing tabs for indent level
+Error: TOO_FEW_TAB          (line:  50, col:   7):	Missing tabs for indent level
+Error: TOO_MANY_INSTR       (line:  50, col:   7):	Too many instructions on a single line
+Error: NO_SPC_BFR_OPR       (line:  50, col:  14):	extra space before operator
+Error: BRACE_SHOULD_EOL     (line:  50, col:  15):	Expected newline after brace
+Error: TOO_FEW_TAB          (line:  50, col:  15):	Missing tabs for indent level
+Error: TOO_MANY_INSTR       (line:  50, col:  15):	Too many instructions on a single line
+Error: TOO_FEW_TAB          (line:  50, col:  16):	Missing tabs for indent level
+Error: TOO_MANY_INSTR       (line:  50, col:  16):	Too many instructions on a single line
+Error: TOO_MANY_FUNCS       (line:  53, col:   1):	Too many functions in file
+Error: NL_AFTER_VAR_DECL    (line:  56, col:   1):	Variable declarations must be followed by a newline
+Error: BRACE_SHOULD_EOL     (line:  56, col:   5):	Expected newline after brace
+Error: TOO_FEW_TAB          (line:  56, col:   6):	Missing tabs for indent level
+Error: TOO_MANY_INSTR       (line:  56, col:   6):	Too many instructions on a single line
+Error: MIXED_SPACE_TAB      (line:  57, col:   1):	Mixed spaces and tabs
+Error: TOO_FEW_TAB          (line:  57, col:   1):	Missing tabs for indent level
+Error: NO_SPC_BFR_OPR       (line:  57, col:  16):	extra space before operator
+Error: TOO_FEW_TAB          (line:  57, col:  17):	Missing tabs for indent level
+Error: TOO_MANY_INSTR       (line:  57, col:  17):	Too many instructions on a single line

--- a/tests/rules/samples/testfile_210104.out
+++ b/tests/rules/samples/testfile_210104.out
@@ -33,5 +33,5 @@
 [36mtestfile_210104.h[0m - [32mIsComment[0m In "GlobalScope" from "None" line 17":
 		<COMMENT=// issue 11, 12 (partly)> <NEWLINE>
 testfile_210104.h: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: PREPROC_CONSTANT     (line:  12, col:  15):	[0mPreprocessor statement must only contain constant defines[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: PREPROC_CONSTANT     (line:  12, col:  15):	Preprocessor statement must only contain constant defines

--- a/tests/rules/samples/testfile_210104_2.out
+++ b/tests/rules/samples/testfile_210104_2.out
@@ -49,6 +49,6 @@
 [36mtestfile_210104_2.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 25":
 		<RBRACE> <NEWLINE>
 testfile_210104_2.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: WRONG_SCOPE_COMMENT  (line:   5, col:   5):	[95mComment is invalid in this scope[0m
-Error: FORBIDDEN_TYPEDEF    (line:  18, col:   1):	[0mTypedef declaration are not allowed in .c files[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: WRONG_SCOPE_COMMENT  (line:   5, col:   5):	Comment is invalid in this scope
+Error: FORBIDDEN_TYPEDEF    (line:  18, col:   1):	Typedef declaration are not allowed in .c files

--- a/tests/rules/samples/testfile_210104_3.out
+++ b/tests/rules/samples/testfile_210104_3.out
@@ -45,6 +45,6 @@
 [36mtestfile_210104_3.c[0m - [32mIsBlockEnd[0m In "Function" from "GlobalScope" line 23":
 		<RBRACE> <NEWLINE>
 testfile_210104_3.c: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: SPC_AFTER_OPERATOR   (line:  20, col:  20):	[94mmissing space after operator[0m
-Error: SPC_AFTER_OPERATOR   (line:  21, col:  24):	[94mmissing space after operator[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: SPC_AFTER_OPERATOR   (line:  20, col:  20):	missing space after operator
+Error: SPC_AFTER_OPERATOR   (line:  21, col:  24):	missing space after operator

--- a/tests/rules/samples/testfile_210104_4.out
+++ b/tests/rules/samples/testfile_210104_4.out
@@ -22,5 +22,5 @@
 		<RBRACE> <NEWLINE>
 testfile_210104_4.c: Error!
 Notice: GLOBAL_VAR_DETECTED  (line:   1, col:   1):	Global variable present in file. Make sure it is a reasonable choice.
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
-Error: SPC_AFTER_OPERATOR   (line:   5, col:   7):	[94mmissing space after operator[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header
+Error: SPC_AFTER_OPERATOR   (line:   5, col:   7):	missing space after operator

--- a/tests/rules/samples/testfile_210108.out
+++ b/tests/rules/samples/testfile_210108.out
@@ -29,4 +29,4 @@
 [36mtestfile_210108.h[0m - [32mIsPreprocessorStatement[0m In "GlobalScope" from "None" line 15":
 		<HASH> <IDENTIFIER=endif> 
 testfile_210108.h: Error!
-Error: INVALID_HEADER       (line:   1, col:   1):	[97mMissing or invalid 42 header[0m
+Error: INVALID_HEADER       (line:   1, col:   1):	Missing or invalid 42 header

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -14,52 +14,46 @@ from norminette.errors import Error, Errors, Highlight as H
 from norminette.errors import HumanizedErrorsFormatter
 
 
-@pytest.mark.parametrize(
-    "files, expected_result, ",
-    [
-        it.values()
-        for it in [
-            {
-                "files": [
-                    File("/nium/a.c", "#include <stdio.h>"),
-                    File("/nium/b.c", "int\tmain(void)\n{\n\treturn (1);\n}\n"),
-                    File("/nium/c.c", "int\tfn(int n);\n"),
-                ],
-                "expected_result": "a.c: OK!\nb.c: OK!\nc.c: OK!\n",
-            },
-            {
-                "files": [
-                    File("skyfall.c", "// Hello"),
-                ],
-                "expected_result": "skyfall.c: OK!\n",
-            },
-            {
-                "files": [
-                    File("/nium/mortari.c", "#define TRUE 1"),
-                    File("/nium/gensler.c", "int\tmain();\n"),
-                ],
-                "expected_result": (
-                    "mortari.c: OK!\n"
-                    "gensler.c: Error!\n"
-                    "Error: NO_ARGS_VOID         (line:   1, col:  10):\t"
-                    "\033[0mEmpty function argument requires void\033[0m\n"
-                ),
-            },
-            {
-                "files": [
-                    File("/nium/john.c", "#define x"),
-                    File("/nium/galt.c", "#define x"),
-                ],
-                "expected_result": (
-                    "john.c: Error!\n"
-                    "Error: MACRO_NAME_CAPITAL   (line:   1, col:   9):\t\033[0mMacro name must be capitalized\033[0m\n"
-                    "galt.c: Error!\n"
-                    "Error: MACRO_NAME_CAPITAL   (line:   1, col:   9):\t\033[0mMacro name must be capitalized\033[0m\n"
-                ),
-            },
-        ]
-    ],
-)
+@pytest.mark.parametrize("files, expected_result, ", [it.values() for it in [
+        {
+            "files": [
+                File("/nium/a.c", "#include <stdio.h>"),
+                File("/nium/b.c", "int\tmain(void)\n{\n\treturn (1);\n}\n"),
+                File("/nium/c.c", "int\tfn(int n);\n"),
+            ],
+            "expected_result": "a.c: OK!\nb.c: OK!\nc.c: OK!\n",
+        },
+        {
+            "files": [
+                File("skyfall.c", "// Hello"),
+            ],
+            "expected_result": "skyfall.c: OK!\n",
+        },
+        {
+            "files": [
+                File("/nium/mortari.c", "#define TRUE 1"),
+                File("/nium/gensler.c", "int\tmain();\n"),
+            ],
+            "expected_result": (
+                "mortari.c: OK!\n"
+                "gensler.c: Error!\n"
+                "Error: NO_ARGS_VOID         (line:   1, col:  10):\tEmpty function argument requires void\n"
+            )
+        },
+        {
+            "files": [
+                File("/nium/john.c", "#define x"),
+                File("/nium/galt.c", "#define x"),
+            ],
+            "expected_result": (
+                "john.c: Error!\n"
+                "Error: MACRO_NAME_CAPITAL   (line:   1, col:   9):\tMacro name must be capitalized\n"
+                "galt.c: Error!\n"
+                "Error: MACRO_NAME_CAPITAL   (line:   1, col:   9):\tMacro name must be capitalized\n"
+            )
+        },
+    ]
+])
 def test_humanized_formatter_errored_file(files: List[File], expected_result: str):
     registry = Registry()
 
@@ -84,24 +78,15 @@ tests = [
                     "errors": [
                         {
                             "name": "INVALID_HEADER",
-                            "text": "\033[97mMissing or invalid 42 header\033[0m",
+                            "text": "Missing or invalid 42 header",
                             "level": "Error",
-                            "highlights": [
-                                {"lineno": 1, "column": 1, "length": None, "hint": None}
-                            ],
+                            "highlights": [{"lineno": 1, "column": 1, "length": None, "hint": None}],
                         },
                         {
                             "name": "NO_ARGS_VOID",
-                            "text": "\033[0mEmpty function argument requires void\033[0m",
+                            "text": "Empty function argument requires void",
                             "level": "Error",
-                            "highlights": [
-                                {
-                                    "lineno": 1,
-                                    "column": 10,
-                                    "length": None,
-                                    "hint": None,
-                                }
-                            ],
+                            "highlights": [{"lineno": 1, "column": 10, "length": None, "hint": None}],
                         },
                     ],
                 },
@@ -118,7 +103,7 @@ def test_json_formatter_errored_file(file, test):
     Registry().run(context)
 
     formatter = JSONErrorsFormatter(file)
-    assert str(formatter) == json.dumps(test, separators=(",", ":")) + "\n"
+    assert str(formatter) == json.dumps(test, separators=(',', ':')) + '\n'
 
 
 def test_error_from_name():
@@ -127,23 +112,13 @@ def test_error_from_name():
         Error.from_name("KeyThatDoesNoExists")
 
 
-@pytest.mark.parametrize(
-    "errors",
+@pytest.mark.parametrize("errors", [
     [
-        [
-            Error(
-                "BAD_NAME", "Names can't be started with an '_'", "Error", [H(3, 5, 5)]
-            ),
-            Error(
-                "GLOBAL_VAR",
-                "Global variables detected, take care",
-                "Notice",
-                [H(2, 1, 1)],
-            ),
-            Error("test", "ola", "Error", [H(1, 1, 1)]),
-        ],
+        Error("BAD_NAME", "Names can't be started with an '_'", "Error", [H(3, 5, 5)]),
+        Error("GLOBAL_VAR", "Global variables detected, take care", "Notice", [H(2, 1, 1)]),
+        Error("test", "ola", "Error", [H(1, 1, 1)]),
     ],
-)
+])
 def test_add_error_signature(errors: List[Error]):
     sequence = Errors()
 
@@ -154,17 +129,9 @@ def test_add_error_signature(errors: List[Error]):
     assert list(errors) == errors
 
 
-@pytest.mark.parametrize(
-    "args, kwargs",
-    [
-        [
-            [
-                "NO_ARGS_VOID",
-            ],
-            {"highlights": [H(1, 1, 2)]},
-        ],
-    ],
-)
+@pytest.mark.parametrize("args, kwargs", [
+    [["NO_ARGS_VOID",], {"highlights": [H(1, 1, 2)]}],
+])
 def test_add_name_signature(args, kwargs):
     assert isinstance(args, list) and len(args) == 1
     assert set() == set(kwargs) - {"level", "highlights"}


### PR DESCRIPTION
The #492 introduced two bugs by not placing the colorizing logic inside the formatter classes:
- Forces `JSONErrorsFormatter` to output colored errors.
- Breaks all tests that don't return `OK`.
  - The #536 attempted to fix this, but only forced tests to pass.

This PR properly fixes both by moving the colorizing logic to `errors.py`, inside `HumanizedErrorsFormatter`, where it belongs.

It also adds a `--no-colors` flag to disable colored output and removes `NormError` and `NormWarning`, now deprecated in favor of the centralized formatting in `errors.py`.