### PR TITLE
Check for None in IsFunctionCall

### DIFF
--- a/norminette/rules/is_function_call.py
+++ b/norminette/rules/is_function_call.py
@@ -128,7 +128,9 @@ class IsFunctionCall(Rule, Primary, priority=80):
                     expected = "SEMI_COLON"
                 else:
                     expected = SEPARATORS
-                while not context.check_token(i, expected):
+                while (not context.check_token(i, expected)
+                       and context.peek_token(i) is not None
+                       ):
                     i += 1
                 i += 1
                 i = context.eol(i)


### PR DESCRIPTION
## Issues Fixed
- Closes #551

## Verification Steps
- [ ] Added new tests to cover the changes.
- [ ] Fixed all broken tests.
- [x] Ran `poetry run flake8` to check for linting issues.
- [x] Verified that all unit tests are passing:
  - [x] Ran `poetry run pytest` to ensure unit tests pass.
  - [x] Ran `poetry run tox` to validate compatibility across Python versions.

## Additional Notes
Macro functions aren't allowed in the norm and every other function needs to be followed by semicolon, so I think it's fine to just error out of norminette when semicolon isn't found. Hitting an exception is better than hanging at the very least.