### PR TITLE
Disable colors in non-interactive environments

### DIFF
--- a/norminette/__main__.py
+++ b/norminette/__main__.py
@@ -75,7 +75,10 @@ def main():
         default="humanized",
     )
     parser.add_argument(
-        "--no-colors", action="store_true", help="Disable colors in output"
+        "--color",
+        choices=["auto", "always", "never"],
+        help="Colorize output",
+        default="auto",
     )
     parser.add_argument("-R", nargs=1, help="compatibility for norminette 2")
     args = parser.parse_args()
@@ -142,7 +145,11 @@ def main():
             sys.exit(1)
         except KeyboardInterrupt:
             sys.exit(1)
-    errors = format(files, use_colors=not args.no_colors)
+    if args.color == "auto":
+        use_colors = sys.stdout.isatty()
+    else:
+        use_colors = args.color == "always"
+    errors = format(files, use_colors=use_colors)
     print(errors, end="")
     sys.exit(1 if len(file.errors) else 0)
 


### PR DESCRIPTION
## Issues Fixed
Currently, output is always colorized unless the `--no-colors` argument is given. But in editor plugins that integrate norminette, the escape sequences can cause problems. Usually, programs that support colorized output disable colors when running in a non-interactive environment. This PR introduces that behavior.

## Changes
- Removed the `--no-colors` argument
- Introduced the `--color {auto,always,never}` argument

## Verification Steps
Please ensure the following steps have been completed:
- [ ] ~~Added new tests to cover the changes.~~ N/A
- [ ] ~~Fixed all broken tests.~~ N/A
- [X] Ran `poetry run flake8` to check for linting issues.
  - Errors showed up, but none are related to this PR.
- [X] Verified that all unit tests are passing:
  - [X] Ran `poetry run pytest` to ensure unit tests pass.
  - [X] Ran `poetry run tox` to validate compatibility across Python versions.
