### PR TITLE
feat: allow ternary in define with -R CheckDefine

### DIFF
--- a/norminette/rules/check_ternary.py
+++ b/norminette/rules/check_ternary.py
@@ -7,6 +7,12 @@ class CheckTernary(Rule, Check):
         Ternaries are forbidden
         """
         for i in range(0, context.tkn_scope):
+            if (
+                context.check_token(i, "IDENTIFIER")
+                and context.peek_token(i).value == "define"
+                and context.preproc.skip_define
+            ):
+                return
             if context.check_token(i, "TERN_CONDITION") is True:
                 context.new_error("TERNARY_FBIDDEN", context.peek_token(i))
         return False, 0


### PR DESCRIPTION
## Jira Issues Fixed
- Closes IN-5461

Resume of the Jira ticket :
---
We have a pisciner who submitted the code below to validate the ft_abs.h which pisciners needs to create macro from the code below. Pisciner has submitted the code below but the norminette >=3.3.51 doesn’t pass. But the next one pass.

```c
# define ABS(Value) Value < 0 ? -Value : Value
```
```c
# define ABS(Value) Value * (Value >= 0) + -Value * (Value < 0)
```

It’s quite complicated as exercise if they need to think this kind of code to validate the exercises.

---
