### PR TITLE
Fix incorrect regex for integer literals

### DIFF
--- a/norminette/lexer/lexer.py
+++ b/norminette/lexer/lexer.py
@@ -50,7 +50,7 @@ INT_LITERAL_PATTERN = re.compile(r"""
 ^
 # (?P<Sign>[-+]*)
 (?P<Prefix>         # prefix can be
-    0[bBxX]*        #   0, 0b, 0B, 0x, 0X, 0bb, 0BB, ...
+    0(b+|B+|x+|X+)? #   0, 0b, 0B, 0x, 0X, 0bb, 0BB, ...
     |               # or empty
 )
 (?P<Constant>


### PR DESCRIPTION
I recently noticed that the regex responsible for parsing integer literals doesn't work as expected.
The prefix part of the regex matches for `[bBxX]*` which caused any combination of `bBxX` to be matched, instead of only matching repeating sequences: https://regex101.com/r/5lUQ0U/1

In cases like `0xb0b`; `0xb` is considered the prefix of the integer literal, causing the last `b` to be matched as an invalid suffix.

In the modified regex combinations can no longer match, only repetitions are allowed: https://regex101.com/r/nWkXWv/1

I'm not sure about how to run tests. The tests seems to fail on the current master branch. With more information, I might be able to add tests for this modified regex.

## Verification Steps
Please ensure the following steps have been completed:
- [ ] Added new tests to cover the changes.
- [ ] Fixed all broken tests.
- [ ] Ran `poetry run flake8` to check for linting issues.
- [ ] Verified that all unit tests are passing:
  - [ ] Ran `poetry run pytest` to ensure unit tests pass.
  - [ ] Ran `poetry run tox` to validate compatibility across Python versions.