### PR TITLE
Add detected errors count at the end

### DIFF
--- a/norminette/__main__.py
+++ b/norminette/__main__.py
@@ -142,8 +142,10 @@ def main():
         except KeyboardInterrupt:
             sys.exit(1)
     errors = format(files, use_colors=not args.no_colors)
+    total_errors = sum(len(file.errors) for file in files)
     print(errors, end="")
-    sys.exit(1 if any(len(it.errors) for it in files) else 0)
+    print(f"{total_errors} norm errors detected")
+    sys.exit(1 if total_errors else 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Just a simple 3 line change to display how many Norm errors have been detected.

# Why?

Is there are many `.c`/`.h` files in a given project (e.g. `libft`) `norminette` output requires a lot of scrolling, adding `"%d norm errors detected"` at the end helps us know if there are any (0 means no errors, anything else means there is an error)

## Verification Steps
Please ensure the following steps have been completed:
- [x] Ran `poetry run flake8` to check for linting issues.
- [x] Verified that all unit tests are passing:
  - [x] Ran `poetry run pytest` to ensure unit tests pass.
  - [x] Ran `poetry run tox` to validate compatibility across Python versions.
